### PR TITLE
Make sure we're using PDO

### DIFF
--- a/php/util.php
+++ b/php/util.php
@@ -8,7 +8,7 @@ function connect($dsn)
 {
     try {
         return \Doctrine\DBAL\DriverManager::getConnection(
-            array('url' => $dsn, 'charset' => 'utf8', 'driver' => 'pdo_mysql')
+            array('url' => $dsn, 'charset' => 'utf8', 'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver')
         );
     } catch (Exception $e) {
         fail("Database error: " . $e->getMessage());


### PR DESCRIPTION
[Here](https://github.com/webfactory/slimdump/blob/7125abe60164397c506dc451137855791088e984/src/Webfactory/Slimdump/Database/Dumper.php#L109) we're setting PDO attributes for the DB connection to work with buffered queries. 

We should assert that the underlying connection is in fact PDO, otherwise this call will fail.

Also, [this line](https://github.com/webfactory/slimdump/blob/7125abe60164397c506dc451137855791088e984/php/util.php#L11) is probably supposed to use PDO as the driver, but it seems passing DSNs like `mysqli://...` will override the setting.
