### PR TITLE
Add option to avoid dumping AUTO_INCREMENT values

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,16 @@ Example:
   <!-- Dump the "media" table, omit BLOB fields. -->
   <table name="media" dump="noblob" />
   
-  <!-- Dump the "users" table, hide names and email addresses. -->
+  <!-- Dump the "user" table, hide names and email addresses. -->
   <table name="user" dump="full">
       <column name="username" dump="masked" />
       <column name="email" dump="masked" />
       <column name="password" dump="replace" replacement="test" />
   </table>
   
+  <!-- Dump the "document" table but do not pass the "AUTO_INCREMENT" parameter to the SQL query.
+       Instead start to increment from the beginning -->
+  <table name="document" dump="full" keep-auto-increment="false" />
 </slimdump>
 ```
 

--- a/src/Webfactory/Slimdump/Config/Table.php
+++ b/src/Webfactory/Slimdump/Config/Table.php
@@ -18,7 +18,7 @@ class Table
     private $dump;
 
     /** @var boolean */
-    private $autoIncrement;
+    private $keepAutoIncrement;
 
     /** @var \SimpleXMLElement */
     private $config;
@@ -45,7 +45,7 @@ class Table
             throw new InvalidDumpTypeException(sprintf("Invalid dump type %s for table %s.", $attr->dump, $this->selector));
         }
 
-        $this->autoIncrement = self::attributeToBoolean($attr->{'auto-increment'}, true);
+        $this->keepAutoIncrement = self::attributeToBoolean($attr->{'keep-auto-increment'}, true);
 
         foreach ($config->column as $columnConfig) {
             $column = new Column($columnConfig);
@@ -92,9 +92,9 @@ class Table
     /**
      * @return boolean
      */
-    public function isAutoIncrement()
+    public function keepAutoIncrement()
     {
-        return $this->autoIncrement;
+        return $this->keepAutoIncrement;
     }
 
     /**

--- a/src/Webfactory/Slimdump/Config/Table.php
+++ b/src/Webfactory/Slimdump/Config/Table.php
@@ -16,6 +16,10 @@ class Table
 {
     private $selector;
     private $dump;
+
+    /** @var boolean */
+    private $autoIncrement;
+
     /** @var \SimpleXMLElement */
     private $config;
 
@@ -41,10 +45,24 @@ class Table
             throw new InvalidDumpTypeException(sprintf("Invalid dump type %s for table %s.", $attr->dump, $this->selector));
         }
 
+        $this->autoIncrement = self::attributeToBoolean($attr->{'auto-increment'}, true);
+
         foreach ($config->column as $columnConfig) {
             $column = new Column($columnConfig);
             $this->columns[$column->getSelector()] = $column;
         }
+    }
+
+    /**
+     * @param \SimpleXMLElement[]|null $attribute
+     * @param boolean $defaultValue
+     * @return boolean
+     */
+    private static function attributeToBoolean($attribute, $defaultValue) {
+        if ($attribute == null) {
+            return $defaultValue;
+        }
+        return ($attribute == 'true') ? true : false;
     }
 
     /**
@@ -69,6 +87,14 @@ class Table
     public function isDataDumpRequired()
     {
         return $this->dump >= Config::NOBLOB;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isAutoIncrement()
+    {
+        return $this->autoIncrement;
     }
 
     /**

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -39,7 +39,7 @@ class Dumper
      * @param Connection $db
      * @param boolean $noAutoIncrement
      */
-    public function dumpSchema($table, Connection $db, $noAutoIncrement)
+    public function dumpSchema($table, Connection $db, $noAutoIncrement = false)
     {
         $this->output->writeln("-- BEGIN STRUCTURE $table");
         $this->output->writeln("DROP TABLE IF EXISTS `$table`;");

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -46,7 +46,7 @@ class Dumper
 
         $tableCreationCommand = $db->fetchColumn("SHOW CREATE TABLE `$table`", array(), 1);
 
-        if (!$tableConfig->isAutoIncrement()) {
+        if (!$tableConfig->keepAutoIncrement()) {
             $tableCreationCommand = preg_replace('/ AUTO_INCREMENT=[0-9]*/', '', $tableCreationCommand);
         }
 

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -39,14 +39,14 @@ class Dumper
      * @param Table         $tableConfig
      * @param Connection    $db
      */
-    public function dumpSchema($table, Table $tableConfig, Connection $db)
+    public function dumpSchema($table, Connection $db, $keepAutoIncrement = true)
     {
         $this->output->writeln("-- BEGIN STRUCTURE $table");
         $this->output->writeln("DROP TABLE IF EXISTS `$table`;");
 
         $tableCreationCommand = $db->fetchColumn("SHOW CREATE TABLE `$table`", array(), 1);
 
-        if (!$tableConfig->keepAutoIncrement()) {
+        if (!$keepAutoIncrement) {
             $tableCreationCommand = preg_replace('/ AUTO_INCREMENT=[0-9]*/', '', $tableCreationCommand);
         }
 

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -37,12 +37,20 @@ class Dumper
     /**
      * @param            $table
      * @param Connection $db
+     * @param boolean $noAutoIncrement
      */
-    public function dumpSchema($table, Connection $db)
+    public function dumpSchema($table, Connection $db, $noAutoIncrement)
     {
         $this->output->writeln("-- BEGIN STRUCTURE $table");
         $this->output->writeln("DROP TABLE IF EXISTS `$table`;");
 
+        $tableCreationCommand = $db->fetchColumn("SHOW CREATE TABLE `$table`", array(), 1);
+
+        if ($noAutoIncrement) {
+            $tableCreationCommand = preg_replace('/ AUTO_INCREMENT=[0-9]*/', '', $tableCreationCommand);
+        }
+
+        $this->output->writeln($tableCreationCommand.";\n", OutputInterface::OUTPUT_RAW);
         $this->output->writeln($db->fetchColumn("SHOW CREATE TABLE `$table`", array(), 1).";\n");
 
         $progress = new ProgressBar($this->output, 1);

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -35,23 +35,22 @@ class Dumper
     }
 
     /**
-     * @param            $table
-     * @param Connection $db
-     * @param boolean $noAutoIncrement
+     * @param               $table
+     * @param Table         $tableConfig
+     * @param Connection    $db
      */
-    public function dumpSchema($table, Connection $db, $noAutoIncrement = false)
+    public function dumpSchema($table, Table $tableConfig, Connection $db)
     {
         $this->output->writeln("-- BEGIN STRUCTURE $table");
         $this->output->writeln("DROP TABLE IF EXISTS `$table`;");
 
         $tableCreationCommand = $db->fetchColumn("SHOW CREATE TABLE `$table`", array(), 1);
 
-        if ($noAutoIncrement) {
+        if (!$tableConfig->isAutoIncrement()) {
             $tableCreationCommand = preg_replace('/ AUTO_INCREMENT=[0-9]*/', '', $tableCreationCommand);
         }
 
         $this->output->writeln($tableCreationCommand.";\n", OutputInterface::OUTPUT_RAW);
-        $this->output->writeln($db->fetchColumn("SHOW CREATE TABLE `$table`", array(), 1).";\n");
 
         $progress = new ProgressBar($this->output, 1);
         $format = "Dumping schema <fg=cyan>$table</>: <fg=yellow>%percent:3s%%</>";

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -35,21 +35,19 @@ class SlimdumpCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $dsn = $input->getArgument('dsn');
-        $noAutoIncrement = $input->getOption('no-auto-increment');
         $db = connect($dsn);
 
         $config = ConfigBuilder::createConfigurationFromConsecutiveFiles($input->getArgument('config'));
-        $this->dump($config, $db, $output, $noAutoIncrement);
+        $this->dump($config, $db, $output);
     }
 
     /**
      * @param Config $config
      * @param Connection $db
      * @param OutputInterface $output
-     * @param boolean $noAutoIncrement
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function dump(Config $config, Connection $db, OutputInterface $output, $noAutoIncrement)
+    public function dump(Config $config, Connection $db, OutputInterface $output)
     {
         $dumper = new Dumper($output);
         $dumper->exportAsUTF8();

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -65,7 +65,7 @@ class SlimdumpCommand extends Command
             }
 
             if ($tableConfig->isSchemaDumpRequired()) {
-                $dumper->dumpSchema($tableName, $tableConfig, $db);
+                $dumper->dumpSchema($tableName, $db, $tableConfig->keepAutoIncrement());
 
                 if ($tableConfig->isDataDumpRequired()) {
                     $dumper->dumpData($tableName, $tableConfig, $db);

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -29,12 +29,6 @@ class SlimdumpCommand extends Command
                 InputArgument::IS_ARRAY | InputArgument::REQUIRED,
                 'Configuration files (at least one).'
             )
-            ->addOption(
-                'no-auto-increment',
-                'nai',
-                InputArgument::OPTIONAL,
-                'Turn off auto increment from the last id of the existing database'
-            )
         ;
     }
     
@@ -73,7 +67,7 @@ class SlimdumpCommand extends Command
             }
 
             if ($tableConfig->isSchemaDumpRequired()) {
-                $dumper->dumpSchema($tableName, $db, $noAutoIncrement);
+                $dumper->dumpSchema($tableName, $tableConfig, $db);
 
                 if ($tableConfig->isDataDumpRequired()) {
                     $dumper->dumpData($tableName, $tableConfig, $db);

--- a/test/Webfactory/Slimdump/Config/TableTest.php
+++ b/test/Webfactory/Slimdump/Config/TableTest.php
@@ -96,4 +96,27 @@ class TableTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $table->getCondition());
     }
 
+    public function testKeepAutoIncrementWhenNotSet()
+    {
+        $xml = '<?xml version="1.0" ?>
+                <table name="dicht*" dump="full" />';
+
+        $xmlElement = new \SimpleXMLElement($xml);
+
+        $table = new Table($xmlElement);
+
+        $this->assertTrue($table->keepAutoIncrement());
+    }
+
+    public function testKeepAutoIncrementWhenSet()
+    {
+        $xml = '<?xml version="1.0" ?>
+                <table name="dicht*" dump="full" keep-auto-increment="false" />';
+
+        $xmlElement = new \SimpleXMLElement($xml);
+
+        $table = new Table($xmlElement);
+
+        $this->assertFalse($table->keepAutoIncrement());
+    }
 }


### PR DESCRIPTION
We're using `SHOW CREATE TABLE` to get the table creation SQL, but that includes the `AUTO_INCREMENT` value (at least for some storage engines).

Depending on the use case, it would be nice to be able to get rid of that.
