### PR TITLE
Use OutputInterface::OUTPUT_RAW to reduce memory consumption

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.3.9",
         "doctrine/dbal": "^2.5.2",
-        "symfony/console": "^2.7"
+        "symfony/console": "2.8.x-dev"
     },
     "autoload": {
         "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "89f9d5396530bb64267790e98c33b3cd",
-    "content-hash": "929236f9c8dc70059ae198e5c35c0182",
+    "hash": "61adbeb24faa6013db106e5c31486933",
+    "content-hash": "9aafd5ec622eb1c79dbb37c43de539ef",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -478,25 +478,26 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.7",
+            "version": "2.8.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "16bb1cb86df43c90931df65f529e7ebd79636750"
+                "reference": "4c5d4cec2a92d3bfcdda90f08ac232ac8d3a8426"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/16bb1cb86df43c90931df65f529e7ebd79636750",
-                "reference": "16bb1cb86df43c90931df65f529e7ebd79636750",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4c5d4cec2a92d3bfcdda90f08ac232ac8d3a8426",
+                "reference": "4c5d4cec2a92d3bfcdda90f08ac232ac8d3a8426",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1",
-                "symfony/process": "~2.1"
+                "symfony/event-dispatcher": "~2.1|~3.0.0",
+                "symfony/process": "~2.1|~3.0.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -506,7 +507,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -533,7 +534,66 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-11-18 09:54:26"
+            "time": "2016-06-03 11:06:57"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-05-18 14:26:46"
         }
     ],
     "packages-dev": [
@@ -2350,12 +2410,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "61973327bfb054f6f470de7be033a28b76c1dc20"
+                "reference": "49268ecae576dbc398ab13783e576a620e961f23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/61973327bfb054f6f470de7be033a28b76c1dc20",
-                "reference": "61973327bfb054f6f470de7be033a28b76c1dc20",
+                "url": "https://api.github.com/repos/symfony/config/zipball/49268ecae576dbc398ab13783e576a620e961f23",
+                "reference": "49268ecae576dbc398ab13783e576a620e961f23",
                 "shasum": ""
             },
             "require": {
@@ -2558,12 +2618,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "6f1979c3b0f4c22c77a8a8971afaa7dd07f082ac"
+                "reference": "d9d21cfcc3e202ee34777d6da38897695d4d208d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/6f1979c3b0f4c22c77a8a8971afaa7dd07f082ac",
-                "reference": "6f1979c3b0f4c22c77a8a8971afaa7dd07f082ac",
+                "url": "https://api.github.com/repos/symfony/process/zipball/d9d21cfcc3e202ee34777d6da38897695d4d208d",
+                "reference": "d9d21cfcc3e202ee34777d6da38897695d4d208d",
                 "shasum": ""
             },
             "require": {
@@ -2599,7 +2659,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-06 09:59:23"
+            "time": "2016-01-14 08:33:14"
         },
         {
             "name": "symfony/stopwatch",
@@ -2748,7 +2808,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "symfony/console": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -21,17 +21,17 @@ class Dumper
 
     public function exportAsUTF8()
     {
-        $this->output->writeln("SET NAMES utf8;");
+        $this->output->writeln("SET NAMES utf8;", OutputInterface::OUTPUT_RAW);
     }
 
     public function disableForeignKeys()
     {
-        $this->output->writeln("SET FOREIGN_KEY_CHECKS = 0;\n");
+        $this->output->writeln("SET FOREIGN_KEY_CHECKS = 0;\n", OutputInterface::OUTPUT_RAW);
     }
 
     public function enableForeignKeys()
     {
-        $this->output->writeln("\nSET FOREIGN_KEY_CHECKS = 1;");
+        $this->output->writeln("\nSET FOREIGN_KEY_CHECKS = 1;", OutputInterface::OUTPUT_RAW);
     }
 
     /**
@@ -41,10 +41,10 @@ class Dumper
     public function dumpSchema($table, Connection $db)
     {
         $this->keepalive($db);
-        $this->output->writeln("-- BEGIN STRUCTURE $table");
-        $this->output->writeln("DROP TABLE IF EXISTS `$table`;");
+        $this->output->writeln("-- BEGIN STRUCTURE $table", OutputInterface::OUTPUT_RAW);
+        $this->output->writeln("DROP TABLE IF EXISTS `$table`;", OutputInterface::OUTPUT_RAW);
 
-        $this->output->writeln($db->fetchColumn("SHOW CREATE TABLE `$table`", array(), 1).";\n");
+        $this->output->writeln($db->fetchColumn("SHOW CREATE TABLE `$table`", array(), 1).";\n", OutputInterface::OUTPUT_RAW);
 
         $progress = new ProgressBar($this->output, 1);
         $format = "Dumping schema <fg=cyan>$table</>: <fg=yellow>%percent:3s%%</>";
@@ -89,7 +89,7 @@ class Dumper
 
         $s .= $tableConfig->getCondition();
 
-        $this->output->writeln("-- BEGIN DATA $table");
+        $this->output->writeln("-- BEGIN DATA $table", OutputInterface::OUTPUT_RAW);
 
         $bufferSize = 0;
         $max = 100 * 1024 * 1024; // 100 MB
@@ -116,30 +116,30 @@ class Dumper
 
             // Start a new statement to ensure that the line does not get too long.
             if ($bufferSize && $bufferSize + $b > $max) {
-                $this->output->writeln(";");
+                $this->output->writeln(";", OutputInterface::OUTPUT_RAW);
                 $bufferSize = 0;
             }
 
             if ($bufferSize == 0) {
-                $this->output->write($this->insertValuesStatement($table, $cols));
+                $this->output->write($this->insertValuesStatement($table, $cols), false, OutputInterface::OUTPUT_RAW);
             } else {
-                $this->output->write(",");
+                $this->output->write(",", false, OutputInterface::OUTPUT_RAW);
             }
 
             $firstCol = true;
-            $this->output->write("\n(");
+            $this->output->write("\n(", false, OutputInterface::OUTPUT_RAW);
 
             foreach ($row as $name => $value) {
                 $isBlobColumn = $this->isBlob($name, $cols);
 
                 if (!$firstCol) {
-                    $this->output->write(", ");
+                    $this->output->write(", ", false, OutputInterface::OUTPUT_RAW);
                 }
 
-                $this->output->write($tableConfig->getStringForInsertStatement($name, $value, $isBlobColumn, $db));
+                $this->output->write($tableConfig->getStringForInsertStatement($name, $value, $isBlobColumn, $db), false, OutputInterface::OUTPUT_RAW);
                 $firstCol = false;
             }
-            $this->output->write(")");
+            $this->output->write(")", false, OutputInterface::OUTPUT_RAW);
             $bufferSize += $b;
             $progress->advance();
         }
@@ -152,10 +152,10 @@ class Dumper
         $wrappedConnection->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
 
         if ($bufferSize) {
-            $this->output->writeln(";");
+            $this->output->writeln(";", OutputInterface::OUTPUT_RAW);
         }
 
-        $this->output->writeln('');
+        $this->output->writeln('', OutputInterface::OUTPUT_RAW);
     }
 
     /**


### PR DESCRIPTION
If `OutputInterface::OUTPUT_RAW` is not added, the strings to be written will be passed through output processors that will do some fancy replacements/addtions. That greatly increases the memory footprint so we avoid it.
