### PR TITLE
Reconnect if MySQL server has gone away

### DIFF
--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -40,6 +40,7 @@ class Dumper
      */
     public function dumpSchema($table, Connection $db)
     {
+        $this->keepalive($db);
         $this->output->writeln("-- BEGIN STRUCTURE $table");
         $this->output->writeln("DROP TABLE IF EXISTS `$table`;");
 
@@ -67,6 +68,7 @@ class Dumper
      */
     public function dumpData($table, Table $tableConfig, Connection $db)
     {
+        $this->keepalive($db);
         $cols = $this->cols($table, $db);
 
         $s = "SELECT ";
@@ -203,5 +205,12 @@ class Dumper
         }
         return $l;
     }
-
+    
+    private function keepalive(Connection $db) 
+    {
+        if (false === $db->ping()) {
+            $db->close();
+            $db->connect();
+        }
+    }
 }


### PR DESCRIPTION
This may happen if you're dumping big tables. Seems the MySQL server pushes the data over to the client (being in "writing to net state" for quite some time), but then may switch to "sleep" state while the libmysqlclient in PHP is still reading the data and/or slimdump is writing it to disk.

If `wait_timeout` is short, the MySQL server may close the connection before we issue the next query. This change will make sure the connection is alive before querying for data or table structures.