### PR TITLE
Feature/add faker integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "require": {
         "php": ">=5.3.9",
         "doctrine/dbal": "^2.5.2",
-        "symfony/console": "^2.8.7"
+        "symfony/console": "^2.8.7",
+        "fzaninotto/faker": "^1.6"
     },
     "autoload": {
         "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "82c8dd6fbcded3dfcf43d97b72e77268",
-    "content-hash": "c2842dd1bfc8fab269e0125f771431b1",
+    "content-hash": "fc1c3c743d40b9909f20f2fd69140783",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -73,7 +72,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -143,7 +142,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-31 16:37:02"
+            "time": "2015-12-31T16:37:02+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -209,7 +208,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2015-04-14 22:21:58"
+            "time": "2015-04-14T22:21:58+00:00"
         },
         {
             "name": "doctrine/common",
@@ -282,7 +281,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2015-12-25 13:18:31"
+            "time": "2015-12-25T13:18:31+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -353,7 +352,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2016-01-05 22:11:12"
+            "time": "2016-01-05T22:11:12+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -420,7 +419,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06 14:35:42"
+            "time": "2015-11-06T14:35:42+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -474,7 +473,55 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
+        },
+        {
+            "name": "fzaninotto/faker",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fzaninotto/Faker.git",
+                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0"
+            },
+            "require-dev": {
+                "ext-intl": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~1.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": []
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "time": "2016-04-29T12:21:54+00:00"
         },
         {
             "name": "symfony/console",
@@ -534,7 +581,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 15:06:25"
+            "time": "2016-06-06T15:06:25+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -593,7 +640,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-05-18T14:26:46+00:00"
         }
     ],
     "packages-dev": [
@@ -649,7 +696,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -744,7 +791,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2015-03-18 18:23:50"
+            "time": "2015-03-18T18:23:50+00:00"
         },
         {
             "name": "herrera-io/annotations",
@@ -797,7 +844,7 @@
                 "doctrine",
                 "tokenizer"
             ],
-            "time": "2014-02-03 17:34:08"
+            "time": "2014-02-03T17:34:08+00:00"
         },
         {
             "name": "herrera-io/box",
@@ -857,7 +904,7 @@
             "keywords": [
                 "phar"
             ],
-            "time": "2014-12-03 23:26:45"
+            "time": "2014-12-03T23:26:45+00:00"
         },
         {
             "name": "herrera-io/json",
@@ -917,7 +964,7 @@
                 "schema",
                 "validate"
             ],
-            "time": "2013-10-30 16:51:34"
+            "time": "2013-10-30T16:51:34+00:00"
         },
         {
             "name": "herrera-io/phar-update",
@@ -974,7 +1021,7 @@
                 "phar",
                 "update"
             ],
-            "time": "2013-11-09 17:13:13"
+            "time": "2013-11-09T17:13:13+00:00"
         },
         {
             "name": "herrera-io/version",
@@ -1025,7 +1072,7 @@
                 "semantic",
                 "version"
             ],
-            "time": "2014-05-27 05:29:25"
+            "time": "2014-05-27T05:29:25+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -1091,7 +1138,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2016-01-25 15:43:01"
+            "time": "2016-01-25T15:43:01+00:00"
         },
         {
             "name": "kherge/amend",
@@ -1146,7 +1193,7 @@
                 "phar",
                 "update"
             ],
-            "time": "2014-11-05 15:29:01"
+            "time": "2014-11-05T15:29:01+00:00"
         },
         {
             "name": "kherge/box",
@@ -1213,7 +1260,7 @@
             "keywords": [
                 "phar"
             ],
-            "time": "2016-03-22 03:23:28"
+            "time": "2016-03-22T03:23:28+00:00"
         },
         {
             "name": "phine/exception",
@@ -1262,7 +1309,7 @@
             "keywords": [
                 "exception"
             ],
-            "time": "2013-08-27 17:43:25"
+            "time": "2013-08-27T17:43:25+00:00"
         },
         {
             "name": "phine/path",
@@ -1314,7 +1361,7 @@
                 "path",
                 "system"
             ],
-            "time": "2013-10-15 22:58:04"
+            "time": "2013-10-15T22:58:04+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -1363,7 +1410,7 @@
                     "email": "mike.vanriel@naenius.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "time": "2015-02-03T12:10:50+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -1455,7 +1502,7 @@
                 "x.509",
                 "x509"
             ],
-            "time": "2016-05-13 01:15:21"
+            "time": "2016-05-13T01:15:21+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1517,7 +1564,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-02-15 07:46:21"
+            "time": "2016-02-15T07:46:21+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1579,7 +1626,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1626,7 +1673,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2015-06-21T13:08:43+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1667,7 +1714,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1711,7 +1758,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1760,7 +1807,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2015-09-15T10:49:45+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1832,7 +1879,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-17 03:09:28"
+            "time": "2016-05-17T03:09:28+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1888,7 +1935,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "psr/log",
@@ -1926,7 +1973,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2012-12-21T11:40:51+00:00"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -1994,7 +2041,7 @@
                 "github",
                 "test"
             ],
-            "time": "2013-05-04 08:07:33"
+            "time": "2013-05-04T08:07:33+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -2058,7 +2105,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2015-07-26T15:48:44+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -2110,7 +2157,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -2160,7 +2207,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2016-05-17T03:18:57+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2226,7 +2273,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2015-06-21T07:55:53+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -2277,7 +2324,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -2330,7 +2377,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2365,7 +2412,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -2411,7 +2458,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2015-11-21 02:21:41"
+            "time": "2015-11-21T02:21:41+00:00"
         },
         {
             "name": "symfony/config",
@@ -2464,7 +2511,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-20 11:48:17"
+            "time": "2016-05-20T11:48:17+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2524,7 +2571,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 11:11:27"
+            "time": "2016-06-06T11:11:27+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -2573,7 +2620,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-12 18:27:47"
+            "time": "2016-04-12T18:27:47+00:00"
         },
         {
             "name": "symfony/finder",
@@ -2622,7 +2669,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 11:11:27"
+            "time": "2016-06-06T11:11:27+00:00"
         },
         {
             "name": "symfony/process",
@@ -2671,7 +2718,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 11:11:27"
+            "time": "2016-06-06T11:11:27+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -2720,7 +2767,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-04 07:56:56"
+            "time": "2016-03-04T07:56:56+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2769,7 +2816,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-26 21:46:24"
+            "time": "2016-05-26T21:46:24+00:00"
         },
         {
             "name": "tedivm/jshrink",
@@ -2815,7 +2862,7 @@
                 "javascript",
                 "minifier"
             ],
-            "time": "2015-07-04 07:35:09"
+            "time": "2015-07-04T07:35:09+00:00"
         }
     ],
     "aliases": [],

--- a/src/Webfactory/Slimdump/Config/Column.php
+++ b/src/Webfactory/Slimdump/Config/Column.php
@@ -62,6 +62,14 @@ class Column
         }
 
         if ($this->dump == Config::REPLACE) {
+            /** @var \SimpleXMLElement $replacement */
+            $replacementName = (string)$this->config->attributes()->replacement;
+
+            if (FakerReplacer::isFakerColumn($replacementName)) {
+                $fakerReplacer = new FakerReplacer();
+                return $fakerReplacer->generateReplacement($replacementName);
+            }
+
             return $this->config->attributes()->replacement;
         }
 

--- a/src/Webfactory/Slimdump/Config/FakerReplacer.php
+++ b/src/Webfactory/Slimdump/Config/FakerReplacer.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Webfactory\Slimdump\Config;
+
+use Faker;
+use Webfactory\Slimdump\Exception\InvalidReplacementOptionException;
+
+/**
+ * This class handles column configurations which have a "replacement" option
+ * @see https://github.com/webfactory/slimdump#configuration for configuration tutorial
+ *
+ * @package Webfactory\Slimdump\Config
+ * @author franziskahahn
+ */
+class FakerReplacer
+{
+    const PREFIX = 'FAKER_';
+
+    /** @var \Faker\Generator */
+    private $faker;
+
+    private $replacementOptions = [
+        self::PREFIX . 'NAME' => 'generateFullNameReplacement',
+        self::PREFIX . 'FIRSTNAME' => 'generateFirstNameReplacement',
+        self::PREFIX . 'LASTNAME' => 'generateLastNameReplacement',
+    ];
+
+    /**
+     * FakerReplacer constructor.
+     * TODO: Add functionality which makes locale configurable
+     */
+    public function __construct()
+    {
+        $this->faker = Faker\Factory::create();
+    }
+
+    /**
+     * check if replacement option is a faker option
+     * static to prevent unnecessary instantiation for non-faker columns
+     * @param string $replacement
+     * @return bool
+     */
+    public static function isFakerColumn($replacement)
+    {
+        if (strpos($replacement, self::PREFIX) === 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * wrapper method which calls the method configured in $this->replacementOptions
+     * @param string $replacementId
+     * @return string
+     */
+    public function generateReplacement($replacementId)
+    {
+        $this->validateReplacementConfigured($replacementId);
+        return $this->getReplacementById($replacementId);
+    }
+
+    /**
+     * validates if this type of replacement was configured
+     *
+     * @param string $replacementId
+     * @throws \Webfactory\Slimdump\Exception\InvalidReplacementOptionException if not configured in $this->replacementOptions
+     */
+    private function validateReplacementConfigured($replacementId)
+    {
+        if (!array_key_exists($replacementId, $this->replacementOptions)) {
+            throw new InvalidReplacementOptionException($replacementId . ' is no valid faker replacement');
+        }
+    }
+
+    /**
+     * @param $replacementId
+     * @return string
+     */
+    private function getReplacementById($replacementId)
+    {
+        $methodName = $this->replacementOptions[$replacementId];
+        return $this->$methodName();
+    }
+
+    /**
+     * returns first and lastname separated by space
+     * Please note: This method might be marked as unused in your IDE.
+     * Method is called by wrapper method getReplacementById
+     * @return string
+     */
+    private function generateFullNameReplacement()
+    {
+        return $this->faker->firstName() . ' ' . $this->faker->lastName();
+    }
+
+    /**
+     * returns random first name
+     * Please note: This method might be marked as unused in your IDE.
+     * Method is called by wrapper method getReplacementById
+     * @return string
+     */
+    private function generateFirstNameReplacement()
+    {
+        return $this->faker->firstName();
+    }
+
+    /**
+     * returns random last name
+     * Please note: This method might be marked as unused in your IDE.
+     * Method is called by wrapper method getReplacementById
+     * @return string
+     */
+    private function generateLastNameReplacement()
+    {
+        return $this->faker->lastName();
+    }
+}

--- a/src/Webfactory/Slimdump/Exception/InvalidReplacementOptionException.php
+++ b/src/Webfactory/Slimdump/Exception/InvalidReplacementOptionException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Webfactory\Slimdump\Exception;
+
+/**
+ * Exception for invalid values of "replacement" option
+ * @package Webfactory\Slimdump\Exception
+ */
+class InvalidReplacementOptionException extends \Exception
+{
+
+}

--- a/test/Webfactory/Slimdump/Config/ColumnTest.php
+++ b/test/Webfactory/Slimdump/Config/ColumnTest.php
@@ -38,6 +38,31 @@ class ColumnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('xxxx@xxxx.xxx', $columnConfig->processRowValue('test@fest.com'));
     }
 
+    public function testProcessRowValueFakerReplacement()
+    {
+        $xml = '<?xml version="1.0" ?>
+                <column name="test" dump="replace" replacement="FAKER_NAME" />';
+        $xmlElement = new \SimpleXMLElement($xml);
+
+        $columnConfig = new Column($xmlElement);
+
+        $fakedName = $columnConfig->processRowValue('original user name');
+        $this->assertNotSame('original user name', $fakedName);
+    }
+
+    public function testProcessRowValueStandardReplacement()
+    {
+        $xml = '<?xml version="1.0" ?>
+                <column name="test" dump="replace" replacement="ANON" />';
+        $xmlElement = new \SimpleXMLElement($xml);
+
+        $columnConfig = new Column($xmlElement);
+
+        $replacedName = $columnConfig->processRowValue('original user name');
+        // note: default replacement returns \SimpleXMLElement - just checking content here using assertEquals
+        $this->assertEquals('ANON', $replacedName);
+    }
+
     /**
      * @expectedException \Webfactory\Slimdump\Exception\InvalidDumpTypeException
      */

--- a/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
+++ b/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
@@ -57,7 +57,7 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($replacedValue);
     }
 
-    public function generateFullNameReplacementContainsSpace()
+    public function testGenerateFullNameReplacementContainsSpace()
     {
         $fakerReplacer = new \ReflectionClass(FakerReplacer::class);
         $replacementMethod = $fakerReplacer->getMethod('generateFullNameReplacement');

--- a/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
+++ b/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
@@ -36,7 +36,7 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers FakerReplacer::generateReplacement
+     *
      */
     public function testValidateReplacementConfiguredNotExisting()
     {
@@ -51,7 +51,6 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
     /**
      * @param string $replacementId
      * @dataProvider provideValidReplacementNames
-     * @covers FakerReplacer::getReplacementById
      */
     public function testGetReplacementByIdSuccess($replacementId)
     {
@@ -64,7 +63,7 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers FakerReplacer::generateFullNameReplacement
+     *
      */
     public function testGenerateFullNameReplacementContainsSpace()
     {

--- a/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
+++ b/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
@@ -12,7 +12,7 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @param string $replacementId
-     * @dataProvider provideValidReplacementOptions
+     * @dataProvider provideValidReplacementIds
      */
     public function testIsFakerColumnSuccess($replacementId)
     {
@@ -27,7 +27,7 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
     /**
      * no assertion because we only expect that no exception is thrown
      * @param string $replacementId
-     * @dataProvider provideValidReplacementOptions
+     * @dataProvider provideValidReplacementIds
      */
     public function testValidateReplacementConfiguredExisting($replacementId)
     {
@@ -35,17 +35,23 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
         $fakerReplacer->generateReplacement($replacementId);
     }
 
+    /**
+     * @covers FakerReplacer::generateReplacement
+     */
     public function testValidateReplacementConfiguredNotExisting()
     {
         $fakerReplacer = new FakerReplacer();
 
-        $this->setExpectedException(InvalidReplacementOptionException::class, 'FAKER_FOOBAR is no valid faker replacement');
+        $this->setExpectedException(InvalidReplacementOptionException::class, 'FOOBAR is no valid faker replacement');
+
+        // neither individual property nor faker property
         $fakerReplacer->generateReplacement('FAKER_FOOBAR');
     }
 
     /**
      * @param string $replacementId
-     * @dataProvider provideValidReplacementOptions
+     * @dataProvider provideValidReplacementNames
+     * @covers FakerReplacer::getReplacementById
      */
     public function testGetReplacementByIdSuccess($replacementId)
     {
@@ -57,6 +63,9 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($replacedValue);
     }
 
+    /**
+     * @covers FakerReplacer::generateFullNameReplacement
+     */
     public function testGenerateFullNameReplacementContainsSpace()
     {
         $fakerReplacer = new \ReflectionClass(FakerReplacer::class);
@@ -71,12 +80,25 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
      * provides valid faker replacement ids
      * @return array
      */
-    public function provideValidReplacementOptions()
+    public function provideValidReplacementIds()
     {
         return [
-            [FakerReplacer::PREFIX . 'NAME'],
-            [FakerReplacer::PREFIX . 'FIRSTNAME'],
-            [FakerReplacer::PREFIX . 'LASTNAME'],
+            [FakerReplacer::PREFIX . 'name'], // slimdump personalized faker property
+            [FakerReplacer::PREFIX . 'firstname'], // original faker property
+            [FakerReplacer::PREFIX . 'lastname'], // original faker property
+        ];
+    }
+
+    /**
+     * provides valid faker replacement ids
+     * @return array
+     */
+    public function provideValidReplacementNames()
+    {
+        return [
+            ['name'], // slimdump personalized faker property
+            ['firstname'], // original faker property
+            ['lastname'], // original faker property
         ];
     }
 }

--- a/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
+++ b/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Webfactory\Slimdump\Config;
+
+use Webfactory\Slimdump\Exception\InvalidReplacementOptionException;
+
+/**
+ * Class FakerReplacerTest
+ * @package Webfactory\Slimdump\Config
+ */
+class FakerReplacerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $replacementId
+     * @dataProvider provideValidReplacementOptions
+     */
+    public function testIsFakerColumnSuccess($replacementId)
+    {
+        $this->assertTrue(FakerReplacer::isFakerColumn($replacementId));
+    }
+
+    public function testIsFakerColumnFail()
+    {
+        $this->assertFalse(FakerReplacer::isFakerColumn('NOTFAKER_NAME'));
+    }
+
+    /**
+     * no assertion because we only expect that no exception is thrown
+     * @param string $replacementId
+     * @dataProvider provideValidReplacementOptions
+     */
+    public function testValidateReplacementConfiguredExisting($replacementId)
+    {
+        $fakerReplacer = new FakerReplacer();
+        $fakerReplacer->generateReplacement($replacementId);
+    }
+
+    public function testValidateReplacementConfiguredNotExisting()
+    {
+        $fakerReplacer = new FakerReplacer();
+
+        $this->setExpectedException(InvalidReplacementOptionException::class, 'FAKER_FOOBAR is no valid faker replacement');
+        $fakerReplacer->generateReplacement('FAKER_FOOBAR');
+    }
+
+    /**
+     * @param string $replacementId
+     * @dataProvider provideValidReplacementOptions
+     */
+    public function testGetReplacementByIdSuccess($replacementId)
+    {
+        $fakerReplacer = new \ReflectionClass(FakerReplacer::class);
+        $replacementMethod = $fakerReplacer->getMethod('getReplacementById');
+        $replacementMethod->setAccessible(true);
+
+        $replacedValue = $replacementMethod->invokeArgs(new FakerReplacer(), [$replacementId]);
+        $this->assertNotEmpty($replacedValue);
+    }
+
+    public function generateFullNameReplacementContainsSpace()
+    {
+        $fakerReplacer = new \ReflectionClass(FakerReplacer::class);
+        $replacementMethod = $fakerReplacer->getMethod('generateFullNameReplacement');
+        $replacementMethod->setAccessible(true);
+
+        $replacedValue = $replacementMethod->invoke(new FakerReplacer());
+        $this->assertContains(' ', $replacedValue);
+    }
+
+    /**
+     * provides valid faker replacement ids
+     * @return array
+     */
+    public function provideValidReplacementOptions()
+    {
+        return [
+            [FakerReplacer::PREFIX . 'NAME'],
+            [FakerReplacer::PREFIX . 'FIRSTNAME'],
+            [FakerReplacer::PREFIX . 'LASTNAME'],
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds faker integration to slimdump with two options: 
* All "official" faker properties which need no arguments like lastname or word (see https://github.com/fzaninotto/Faker#basic-usage ) when prefix FAKER_ is used (e.g. FAKER_word)
* One additional (can be extended) option "FAKER_name"  which returns firstname and lastname separated by space.


Please comment before merging because I would like to add user documentation if everything else was discussed! 

Of cause it is still possible to replace column value with static content:
```php
<?xml version="1.0" ?>
<slimdump>
    <table name="users" dump="full" keep-auto-increment="false" condition="`signup_date` >= '2017-01-20 00:00:00'">
        <column name="password" dump="replace" replacement="XXXXX" />
        <column name="username" dump="replace" replacement="FAKER_name" />
    </table>
</slimdump>
```