### PR TITLE
add-faker-integration: removed 'name' because it is an existing faker option

### DIFF
--- a/src/Webfactory/Slimdump/Config/FakerReplacer.php
+++ b/src/Webfactory/Slimdump/Config/FakerReplacer.php
@@ -20,11 +20,12 @@ class FakerReplacer
     private $faker;
 
     /**
-     * configuration for method which are not part of faker itself
+     * configuration for method which are not part of faker itself.
+     * You can implement a new method "methodName" which returns for example a
+     * format: 'suffix' => 'methodName',
      * @var array
      */
     private $replacementOptions = [
-        'name' => 'generateFullNameReplacement',
     ];
 
     /**
@@ -99,16 +100,5 @@ class FakerReplacer
 
         // default faker property
         return $this->faker->$replacementName;
-    }
-
-    /**
-     * returns first and lastname separated by space
-     * Please note: This method might be marked as unused in your IDE.
-     * Method is called by wrapper method getReplacementById
-     * @return string
-     */
-    private function generateFullNameReplacement()
-    {
-        return $this->faker->firstName() . ' ' . $this->faker->lastName();
     }
 }

--- a/src/Webfactory/Slimdump/Config/FakerReplacer.php
+++ b/src/Webfactory/Slimdump/Config/FakerReplacer.php
@@ -20,15 +20,6 @@ class FakerReplacer
     private $faker;
 
     /**
-     * configuration for method which are not part of faker itself.
-     * You can implement a new method "methodName" which returns for example a
-     * format: 'suffix' => 'methodName',
-     * @var array
-     */
-    private $replacementOptions = [
-    ];
-
-    /**
      * FakerReplacer constructor.
      * TODO: Add functionality which makes locale configurable
      */
@@ -53,7 +44,7 @@ class FakerReplacer
     }
 
     /**
-     * wrapper method which calls the method configured in $this->replacementOptions
+     * wrapper method which removes the prefix calls the defined faker method
      * @param string $replacementId
      * @return string
      */
@@ -61,44 +52,21 @@ class FakerReplacer
     {
         $replacementMethodName = str_replace(self::PREFIX, '', $replacementId);
         $this->validateReplacementConfigured($replacementMethodName);
-        return $this->getReplacementById($replacementMethodName);
+        return $this->faker->$replacementMethodName;
     }
 
     /**
      * validates if this type of replacement was configured
      *
      * @param string $replacementName
-     * @throws \Webfactory\Slimdump\Exception\InvalidReplacementOptionException if not configured in $this->replacementOptions
+     * @throws \Webfactory\Slimdump\Exception\InvalidReplacementOptionException if not a faker method
      */
     private function validateReplacementConfigured($replacementName)
     {
-        $isConfiguredReplacement = array_key_exists($replacementName, $this->replacementOptions);
-        $isFakerProperty = true;
-
         try {
             $this->faker->__get($replacementName);
         } catch (\InvalidArgumentException $exception) {
-            $isFakerProperty = false;
-        }
-
-        if (!$isFakerProperty && !$isConfiguredReplacement) {
             throw new InvalidReplacementOptionException($replacementName . ' is no valid faker replacement');
         }
-    }
-
-    /**
-     * @param string $replacementName
-     * @return string
-     */
-    private function getReplacementById($replacementName)
-    {
-        if (array_key_exists($replacementName, $this->replacementOptions)) {
-            // internal function
-            $methodName = $this->replacementOptions[$replacementName];
-            return $this->$methodName();
-        }
-
-        // default faker property
-        return $this->faker->$replacementName;
     }
 }

--- a/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
+++ b/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
@@ -63,26 +63,12 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     *
-     */
-    public function testGenerateFullNameReplacementContainsSpace()
-    {
-        $fakerReplacer = new \ReflectionClass(FakerReplacer::class);
-        $replacementMethod = $fakerReplacer->getMethod('generateFullNameReplacement');
-        $replacementMethod->setAccessible(true);
-
-        $replacedValue = $replacementMethod->invoke(new FakerReplacer());
-        $this->assertContains(' ', $replacedValue);
-    }
-
-    /**
      * provides valid faker replacement ids
      * @return array
      */
     public function provideValidReplacementIds()
     {
         return [
-            [FakerReplacer::PREFIX . 'name'], // slimdump personalized faker property
             [FakerReplacer::PREFIX . 'firstname'], // original faker property
             [FakerReplacer::PREFIX . 'lastname'], // original faker property
         ];
@@ -95,7 +81,6 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
     public function provideValidReplacementNames()
     {
         return [
-            ['name'], // slimdump personalized faker property
             ['firstname'], // original faker property
             ['lastname'], // original faker property
         ];

--- a/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
+++ b/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
@@ -49,20 +49,6 @@ class FakerReplacerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param string $replacementId
-     * @dataProvider provideValidReplacementNames
-     */
-    public function testGetReplacementByIdSuccess($replacementId)
-    {
-        $fakerReplacer = new \ReflectionClass(FakerReplacer::class);
-        $replacementMethod = $fakerReplacer->getMethod('getReplacementById');
-        $replacementMethod->setAccessible(true);
-
-        $replacedValue = $replacementMethod->invokeArgs(new FakerReplacer(), [$replacementId]);
-        $this->assertNotEmpty($replacedValue);
-    }
-
-    /**
      * provides valid faker replacement ids
      * @return array
      */


### PR DESCRIPTION
Hey guys,
I saw that "name" is already (is it new, I never saw it before?! :D) an "official" faker formatter.

So I deleted the self-written formatter. 
I decided to keep the configuration skeleton because I am sure we will need individual stuff in the further development of slimdump. 
