### PR TITLE
Support dumping triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Example:
   <!-- Dump the "document" table but do not pass the "AUTO_INCREMENT" parameter to the SQL query.
        Instead start to increment from the beginning -->
   <table name="document" dump="full" keep-auto-increment="false" />
+  
+  <!-- Omit dumping CREATE TRIGGER statements for the "events" table.
+       By default, triggers will be included whenever the table is dumped
+       as schema or otherwise. -->
+  <table name="events" dump="schema" dump-triggers="false" />
 </slimdump>
 ```
 
@@ -147,9 +152,10 @@ Use slimdump as Phar:
 You can execute the phpunit-tests by calling `vendor/bin/phpunit`. 
 
 ## Credits, Copyright and License
+
 This tool was started at webfactory GmbH in Bonn by [mpdude](https://github.com/mpdude).
 
 - <https://www.webfactory.de>
 - <https://twitter.com/webfactory>
 
-Copyright 2014-2016 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).
+Copyright 2014-2017 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -59,9 +59,18 @@ Example:
        Instead start to increment from the beginning -->
   <table name="document" dump="full" keep-auto-increment="false" />
   
-  <!-- Omit dumping CREATE TRIGGER statements for the "events" table.
-       By default, triggers will be included whenever the table is dumped
-       as schema or otherwise. -->
+  <!-- 
+    Trigger handling: 
+    
+    By default, CREATE TRIGGER statements will be dumped for all tables, but the "DEFINER=..."
+    clause will be removed to make it easier to re-import the database e. g. in development
+    environments. 
+    
+    You can change this by setting 'dump-triggers' to one of:
+        - 'false' or 'none': Do not dump triggers at all
+        - 'true' or 'no-definer': Dump trigger creation statement but remove DEFINER=... clause
+        - 'keep-definer': Keep the DEFINER=... clause
+  -->
   <table name="events" dump="schema" dump-triggers="false" />
 </slimdump>
 ```

--- a/src/Webfactory/Slimdump/Config/Table.php
+++ b/src/Webfactory/Slimdump/Config/Table.php
@@ -14,13 +14,17 @@ use Webfactory\Slimdump\Exception\InvalidDumpTypeException;
  */
 class Table
 {
+    const TRIGGER_SKIP = 0;
+    const TRIGGER_NO_DEFINER = 1;
+    const TRIGGER_KEEP_DEFINER = 2;
+
     private $selector;
     private $dump;
 
     /** @var boolean */
     private $keepAutoIncrement;
 
-    /** @var boolean */
+    /** @var integer */
     private $dumpTriggers;
 
     /** @var \SimpleXMLElement */
@@ -49,7 +53,7 @@ class Table
         }
 
         $this->keepAutoIncrement = self::attributeToBoolean($attr->{'keep-auto-increment'}, true);
-        $this->dumpTriggers = self::attributeToBoolean($attr->{'dump-triggers'}, true);
+        $this->dumpTriggers = self::parseDumpTriggerAttribute($attr->{'dump-triggers'});
 
         foreach ($config->column as $columnConfig) {
             $column = new Column($columnConfig);
@@ -67,6 +71,25 @@ class Table
             return $defaultValue;
         }
         return ($attribute == 'true') ? true : false;
+    }
+
+    private static function parseDumpTriggerAttribute($value)
+    {
+        if ($value === null) {
+            return self::TRIGGER_NO_DEFINER; // default
+        } else if ($value == 'true') {
+            return self::TRIGGER_NO_DEFINER; // BC
+        } else if ($value == 'false') {
+            return self::TRIGGER_SKIP;
+        } else if ($value == 'none') {
+            return self::TRIGGER_SKIP;
+        } else if ($value == 'no-definer') {
+            return self::TRIGGER_NO_DEFINER;
+        } else if ($value == 'keep-definer') {
+            return self::TRIGGER_KEEP_DEFINER;
+        } else {
+            throw new \RuntimeException("Unsupported value '$value' for the 'dump-triggers' setting.");
+        }
     }
 
     /**
@@ -97,6 +120,14 @@ class Table
      * @return boolean
      */
     public function isTriggerDumpRequired()
+    {
+        return $this->dumpTriggers > self::TRIGGER_SKIP;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDumpTriggersLevel()
     {
         return $this->dumpTriggers;
     }

--- a/src/Webfactory/Slimdump/Config/Table.php
+++ b/src/Webfactory/Slimdump/Config/Table.php
@@ -20,6 +20,9 @@ class Table
     /** @var boolean */
     private $keepAutoIncrement;
 
+    /** @var boolean */
+    private $dumpTriggers;
+
     /** @var \SimpleXMLElement */
     private $config;
 
@@ -46,6 +49,7 @@ class Table
         }
 
         $this->keepAutoIncrement = self::attributeToBoolean($attr->{'keep-auto-increment'}, true);
+        $this->dumpTriggers = self::attributeToBoolean($attr->{'dump-triggers'}, true);
 
         foreach ($config->column as $columnConfig) {
             $column = new Column($columnConfig);
@@ -87,6 +91,14 @@ class Table
     public function isDataDumpRequired()
     {
         return $this->dump >= Config::NOBLOB;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isTriggerDumpRequired()
+    {
+        return $this->dumpTriggers;
     }
 
     /**

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -67,6 +67,27 @@ class Dumper
     }
 
     /**
+     * @param Connection $db
+     * @param            $tableName
+     */
+    public function dumpTriggers(Connection $db, $tableName)
+    {
+        $triggers = $db->fetchAll("SHOW TRIGGERS LIKE ?", [$tableName]);
+
+        if (!$triggers) {
+            return;
+        }
+
+        $this->output->writeln("-- BEGIN TRIGGERS $tableName", OutputInterface::OUTPUT_RAW);
+
+        foreach ($triggers as $row) {
+            $createTriggerCommand = $db->fetchColumn("SHOW CREATE TRIGGER `{$row['Trigger']}`", [], 2);
+            $createTriggerCommand = preg_replace('/DEFINER=`[^`]*`@`[^`]*` /', '', $createTriggerCommand);
+            $this->output->writeln($createTriggerCommand.";\n", OutputInterface::OUTPUT_RAW);
+        }
+    }
+
+    /**
      * @param            $table
      * @param Table      $tableConfig
      * @param Connection $db

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -68,9 +68,10 @@ class Dumper
 
     /**
      * @param Connection $db
-     * @param            $tableName
+     * @param string     $tableName
+     * @param integer    $level One of the Table::TRIGGER_* constants
      */
-    public function dumpTriggers(Connection $db, $tableName)
+    public function dumpTriggers(Connection $db, $tableName, $level = Table::TRIGGER_NO_DEFINER)
     {
         $triggers = $db->fetchAll("SHOW TRIGGERS LIKE ?", [$tableName]);
 
@@ -82,7 +83,11 @@ class Dumper
 
         foreach ($triggers as $row) {
             $createTriggerCommand = $db->fetchColumn("SHOW CREATE TRIGGER `{$row['Trigger']}`", [], 2);
-            $createTriggerCommand = preg_replace('/DEFINER=`[^`]*`@`[^`]*` /', '', $createTriggerCommand);
+
+            if ($level == Table::TRIGGER_NO_DEFINER) {
+                $createTriggerCommand = preg_replace('/DEFINER=`[^`]*`@`[^`]*` /', '', $createTriggerCommand);
+            }
+
             $this->output->writeln($createTriggerCommand.";\n", OutputInterface::OUTPUT_RAW);
         }
     }

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -72,7 +72,7 @@ class SlimdumpCommand extends Command
                 }
 
                 if ($tableConfig->isTriggerDumpRequired()) {
-                    $dumper->dumpTriggers($db, $tableName);
+                    $dumper->dumpTriggers($db, $tableName, $tableConfig->getDumpTriggersLevel());
                 }
             }
         }

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -70,6 +70,10 @@ class SlimdumpCommand extends Command
                 if ($tableConfig->isDataDumpRequired()) {
                     $dumper->dumpData($tableName, $tableConfig, $db);
                 }
+
+                if ($tableConfig->isTriggerDumpRequired()) {
+                    $dumper->dumpTriggers($db, $tableName);
+                }
             }
         }
         $dumper->enableForeignKeys();

--- a/test/Webfactory/Slimdump/Config/TableTest.php
+++ b/test/Webfactory/Slimdump/Config/TableTest.php
@@ -119,4 +119,41 @@ class TableTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($table->keepAutoIncrement());
     }
+
+    public function testDumpTriggerDefaultSetting()
+    {
+        $xml = '<?xml version="1.0" ?>
+                <table name="*" dump="full" />';
+
+        $xmlElement = new \SimpleXMLElement($xml);
+        $table = new Table($xmlElement);
+
+        $this->assertEquals($table->getDumpTriggersLevel(), Table::TRIGGER_NO_DEFINER);
+        $this->assertTrue($table->isTriggerDumpRequired());
+    }
+    
+    /** @dataProvider  dumpTriggerAttributeValues */
+    public function testDumpTriggerAttribute($value, $expected)
+    {
+        $xml = '<?xml version="1.0" ?>
+                <table name="*" dump="full" dump-triggers="'.$value.'" />';
+
+        $xmlElement = new \SimpleXMLElement($xml);
+        $table = new Table($xmlElement);
+
+        $this->assertEquals($table->getDumpTriggersLevel(), $expected);
+        $this->assertEquals($table->isTriggerDumpRequired(), $expected !== Table::TRIGGER_SKIP);
+    }
+
+    public function dumpTriggerAttributeValues()
+    {
+        return [
+            ['true', Table::TRIGGER_NO_DEFINER],
+            ['false', Table::TRIGGER_SKIP],
+            ['none', Table::TRIGGER_SKIP],
+            ['no-definer', Table::TRIGGER_NO_DEFINER],
+            ['keep-definer', Table::TRIGGER_KEEP_DEFINER],
+        ];
+    }
+
 }

--- a/test/Webfactory/Slimdump/Database/DumperTest.php
+++ b/test/Webfactory/Slimdump/Database/DumperTest.php
@@ -3,6 +3,7 @@
 namespace Webfactory\Slimdump\Database;
 
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Webfactory\Slimdump\Config\Table;
 
 class DumperTest extends \PHPUnit_Framework_TestCase
@@ -10,11 +11,20 @@ class DumperTest extends \PHPUnit_Framework_TestCase
     /** @var  \PHPUnit_Framework_MockObject_MockObject */
     protected $dbMock;
 
+    /** @var  OutputInterface */
+    protected $outputBuffer;
+
+    /** @var Dumper */
+    protected $dumper;
+
     /**
      * @before
      */
     public function setup()
     {
+        $this->outputBuffer = new BufferedOutput();
+        $this->dumper = new Dumper($this->outputBuffer);
+
         $this->dbMock = $this->getMockBuilder('\Doctrine\DBAL\Connection')
             ->disableOriginalConstructor()
             ->getMock();
@@ -22,13 +32,10 @@ class DumperTest extends \PHPUnit_Framework_TestCase
 
     public function testDumpSchemaWithNormalConfiguration()
     {
-        $outputBuffer = new BufferedOutput();
-        $dumper = new Dumper($outputBuffer);
-
         $this->dbMock->expects($this->any())->method('fetchColumn')->willReturn('CREATE TABLE statement');
 
-        $dumper->dumpSchema('test', $this->dbMock);
-        $output = $outputBuffer->fetch();
+        $this->dumper->dumpSchema('test', $this->dbMock);
+        $output = $this->outputBuffer->fetch();
 
         $this->assertContains('DROP TABLE IF EXISTS', $output);
         $this->assertContains('CREATE TABLE statement', $output);
@@ -36,9 +43,6 @@ class DumperTest extends \PHPUnit_Framework_TestCase
 
     public function testDumpDataWithFullConfiguration()
     {
-        $outputBuffer = new BufferedOutput();
-        $dumper = new Dumper($outputBuffer);
-
         $pdoMock = $this->getMock('\stdClass', array('setAttribute'));
 
         $this->dbMock->expects($this->any())->method('getWrappedConnection')->willReturn($pdoMock);
@@ -83,9 +87,36 @@ class DumperTest extends \PHPUnit_Framework_TestCase
 
         $table = new Table(new \SimpleXMLElement('<table name="test" dump="full" />'));
 
-        $dumper->dumpData('test', $table, $this->dbMock);
-        $output = $outputBuffer->fetch();
+        $this->dumper->dumpData('test', $table, $this->dbMock);
+        $output = $this->outputBuffer->fetch();
 
         $this->assertContains('INSERT INTO', $output);
+    }
+
+    public function testDumpTriggers()
+    {
+        $t1 = 'CREATE DEFINER=`somebody`@`myhost` TRIGGER trigger1 ...';
+        $t2 = 'CREATE DEFINER=`somebody`@`myhost` TRIGGER trigger2 ...';
+
+        $this->dbMock->expects($this->at(0))
+            ->method('fetchAll')
+            ->with('SHOW TRIGGERS LIKE ?', ['test'])
+            ->willReturn([['Trigger' => 'trigger1'], ['Trigger' => 'trigger2']]);
+
+        $this->dbMock->expects($this->at(1))
+            ->method('fetchColumn')
+            ->with('SHOW CREATE TRIGGER `trigger1`')
+            ->willReturn('CREATE DEFINER=`somebody`@`myhost` TRIGGER trigger1 ...');
+
+        $this->dbMock->expects($this->at(2))
+            ->method('fetchColumn')
+            ->with('SHOW CREATE TRIGGER `trigger2`')
+            ->willReturn('CREATE DEFINER=`somebody`@`myhost` TRIGGER trigger2 ...');
+
+        $this->dumper->dumpTriggers($this->dbMock, 'test');
+
+        $output = $this->outputBuffer->fetch();
+        $this->assertContains("CREATE TRIGGER trigger1 ...;", $output);
+        $this->assertContains("CREATE TRIGGER trigger2 ...;", $output);
     }
 }

--- a/test/Webfactory/Slimdump/Database/DumperTest.php
+++ b/test/Webfactory/Slimdump/Database/DumperTest.php
@@ -95,9 +95,6 @@ class DumperTest extends \PHPUnit_Framework_TestCase
 
     public function testDumpTriggers()
     {
-        $t1 = 'CREATE DEFINER=`somebody`@`myhost` TRIGGER trigger1 ...';
-        $t2 = 'CREATE DEFINER=`somebody`@`myhost` TRIGGER trigger2 ...';
-
         $this->dbMock->expects($this->at(0))
             ->method('fetchAll')
             ->with('SHOW TRIGGERS LIKE ?', ['test'])


### PR DESCRIPTION
This will include `CREATE TRIGGER ...` statements when dumping a table. Dumping at `schema` level is sufficient to dump the triggers as well.

If you would like to skip (all) triggers for a table, add `<table ... dump-triggers="false" />` to your config.

Trigger creation statements will be placed after the `INSERT` statements for the table in question, I hope that makes sense.

The `` DEFINER=`user`@`host` `` clause will always be stripped from the `CREATE TRIGGER` statement to make re-importing the dump as another user easier.

Closes #26.

*ping* @MalteWunsch 
