### PR TITLE
Fix configuration for .phar generation

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -1,8 +1,9 @@
 {
     "chmod": "0755",
-    "main": "bin/slimdump.php",
+    "main": "bin/slimdump",
     "directories-bin": [
-        "php"
+        "php",
+        "src"
     ],
     "finder-bin": [
         {


### PR DESCRIPTION
Unfortunately the generation of the .phar package does not work very well. These small adjustments should do the trick.