### PR TITLE
Support Faker modifiers (such as unique)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,16 @@ You can use every Faker option which needs no arguments. Of course you can still
     </table>
 </slimdump>
 ```
+You can also use modifiers, such as `unique`. Just seperate the modifier with an object operator (`->`), as you would do in PHP.
 
+```xml
+<?xml version="1.0" ?>
+<slimdump>
+    <table name="users" dump="full" keep-auto-increment="false" condition="`timestamp` >= '2017-01-20 00:00:00' LIMIT 1">
+        <column name="email" dump="replace" replacement="FAKER_unique->email" />
+    </table>
+</slimdump>
+```
 ## Other databases
 Currently only MySQL is supported. But feel free to port it to the database of your needs.
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "296b99fced02df44cd95a645e86d6c43",
+    "content-hash": "e129ea227863624aa97a4731e2a936b0",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -526,6 +526,55 @@
             "time": "2017-08-15T16:48:10+00:00"
         },
         {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.0.0",
             "source": {
@@ -686,6 +735,76 @@
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
             "time": "2017-10-02T06:42:24+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v3.3.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "8ebad929aee3ca185b05f55d9cc5521670821ad1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/8ebad929aee3ca185b05f55d9cc5521670821ad1",
+                "reference": "8ebad929aee3ca185b05f55d9cc5521670821ad1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8",
+                "psr/container": "^1.0"
+            },
+            "conflict": {
+                "symfony/config": "<3.3.1",
+                "symfony/finder": "<3.3",
+                "symfony/yaml": "<3.3"
+            },
+            "provide": {
+                "psr/container-implementation": "1.0"
+            },
+            "require-dev": {
+                "symfony/config": "~3.3",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/yaml": "~3.3"
+            },
+            "suggest": {
+                "symfony/config": "",
+                "symfony/expression-language": "For using expressions in service container configuration",
+                "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
+                "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DependencyInjection Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-10-04T17:15:30+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",

--- a/src/Webfactory/Slimdump/Config/Column.php
+++ b/src/Webfactory/Slimdump/Config/Column.php
@@ -15,6 +15,7 @@ class Column
 {
 
     private $config = null;
+    private $fakerReplacer;
 
     /**
      * Column constructor.
@@ -35,6 +36,8 @@ class Column
         } else {
             throw new InvalidDumpTypeException(sprintf("Invalid dump type %s for column %s.", $attr->dump, $this->selector));
         }
+
+        $this->fakerReplacer = new FakerReplacer();
     }
 
     /**
@@ -65,9 +68,11 @@ class Column
             /** @var \SimpleXMLElement $replacement */
             $replacementName = (string)$this->config->attributes()->replacement;
 
-            if (FakerReplacer::isFakerColumn($replacementName)) {
-                $fakerReplacer = new FakerReplacer();
-                return $fakerReplacer->generateReplacement($replacementName);
+
+
+            if ($this->fakerReplacer->isFakerColumn($replacementName)) {
+
+                return $this->fakerReplacer->generateReplacement($replacementName);
             }
 
             return $this->config->attributes()->replacement;

--- a/src/Webfactory/Slimdump/Config/FakerReplacer.php
+++ b/src/Webfactory/Slimdump/Config/FakerReplacer.php
@@ -59,11 +59,10 @@ class FakerReplacer
             $modifierName = $modifierAndMethod[0];
             $replacementMethodName = $modifierAndMethod[1];
 
-            $this->validateReplacementConfiguredModifier($modifierName,$replacementMethodName);
+            $this->validateReplacementConfiguredModifier($modifierName, $replacementMethodName);
 
             return (string)$this->faker->$modifierName->$replacementMethodName;
-        }
-        else{
+        } else {
             $this->validateReplacementConfigured($replacementMethodName);
             return (string)$this->faker->$replacementMethodName;
         }

--- a/src/Webfactory/Slimdump/Config/FakerReplacer.php
+++ b/src/Webfactory/Slimdump/Config/FakerReplacer.php
@@ -5,6 +5,7 @@ namespace Webfactory\Slimdump\Config;
 use Faker;
 use Webfactory\Slimdump\Exception\InvalidReplacementOptionException;
 
+
 /**
  * This class handles column configurations which have a "replacement" option
  * @see https://github.com/webfactory/slimdump#configuration for configuration tutorial
@@ -51,8 +52,21 @@ class FakerReplacer
     public function generateReplacement($replacementId)
     {
         $replacementMethodName = str_replace(self::PREFIX, '', $replacementId);
-        $this->validateReplacementConfigured($replacementMethodName);
-        return $this->faker->$replacementMethodName;
+
+        if (strpos($replacementMethodName,'->') !== false) {
+
+            $modifierAndMethod = explode('->',$replacementMethodName);
+            $modifierName = $modifierAndMethod[0];
+            $replacementMethodName = $modifierAndMethod[1];
+
+            $this->validateReplacementConfiguredModifier($modifierName,$replacementMethodName);
+
+            return (string)$this->faker->$modifierName->$replacementMethodName;
+        }
+        else{
+            $this->validateReplacementConfigured($replacementMethodName);
+            return (string)$this->faker->$replacementMethodName;
+        }
     }
 
     /**
@@ -67,6 +81,14 @@ class FakerReplacer
             $this->faker->__get($replacementName);
         } catch (\InvalidArgumentException $exception) {
             throw new InvalidReplacementOptionException($replacementName . ' is no valid faker replacement');
+        }
+    }
+    private function validateReplacementConfiguredModifier($replacementModifier,$replacementName)
+    {
+        try {
+            $this->faker->__get($replacementModifier)->__get($replacementName);
+        } catch (\InvalidArgumentException $exception) {
+            throw new InvalidReplacementOptionException($replacementModifier . "->" . $replacementName . ' is no valid faker replacement');
         }
     }
 }

--- a/test/Webfactory/Slimdump/Config/ColumnTest.php
+++ b/test/Webfactory/Slimdump/Config/ColumnTest.php
@@ -2,6 +2,8 @@
 
 namespace Webfactory\Slimdump\Config;
 
+use phpDocumentor\Reflection\Types\Array_;
+
 class ColumnTest extends \PHPUnit_Framework_TestCase
 {
 
@@ -105,8 +107,23 @@ class ColumnTest extends \PHPUnit_Framework_TestCase
         $xmlElement = new \SimpleXMLElement($xml);
 
         $columnConfig = new Column($xmlElement);
-        $this->assertRegExp('/[0-9a-zA-Z]*/', $columnConfig->processRowValue('test value'));
-        $this->assertNotEquals($columnConfig->processRowValue('test value'),$columnConfig->processRowValue('test value'),$columnConfig->processRowValue('test value'),$columnConfig->processRowValue('test value'));
+
+        $rowValues = array(
+            $columnConfig->processRowValue('test value'),
+            $columnConfig->processRowValue('test value'),
+            $columnConfig->processRowValue('test value'),
+            $columnConfig->processRowValue('test value'),
+            $columnConfig->processRowValue('test value')
+        );
+
+        $this->assertRegExp('/[0-9]/', $rowValues[0]);
+
+        $unique = false;
+
+        if(count($rowValues) === count(array_unique($rowValues)))
+            $unique = true;
+
+        $this->assertTrue($unique);
     }
 
 }

--- a/test/Webfactory/Slimdump/Config/ColumnTest.php
+++ b/test/Webfactory/Slimdump/Config/ColumnTest.php
@@ -97,5 +97,16 @@ class ColumnTest extends \PHPUnit_Framework_TestCase
         $columnConfig = new Column($xmlElement);
         $this->assertEquals('', $columnConfig->processRowValue('test value'));
     }
+    public function testReplaceColumnWithUniqId()
+    {
+        $xml = '<?xml version="1.0" ?>
+                <column name="test" dump="replace" replacement="FAKER_unique->randomDigit" />';
+
+        $xmlElement = new \SimpleXMLElement($xml);
+
+        $columnConfig = new Column($xmlElement);
+        $this->assertRegExp('/[0-9a-zA-Z]*/', $columnConfig->processRowValue('test value'));
+        $this->assertNotEquals($columnConfig->processRowValue('test value'),$columnConfig->processRowValue('test value'),$columnConfig->processRowValue('test value'),$columnConfig->processRowValue('test value'));
+    }
 
 }


### PR DESCRIPTION
Added support for Faker modifiers, such as "unique". Allows to replace database values with fake values, which are unique per column. 