### PR TITLE
Add buffer-size limitation to table config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ Example:
 </slimdump>
 ```
 
+### Buffer sizes
+
+You may are not able to fully administrate your MySQL database. Often you run into problems with the buffer size on really
+big tables. You can set the buffer size per table. Add a suffix (KB, MB or GB) to the value.
+
+Example:
+```xml
+<?xml version="1.0" ?>
+<slimdump>
+  <!-- Limit the buffer size to 12MB -->
+  <table name="*" dump="full" buffer-size="12MB" />
+</slimdump>
+```
+
 ### Dump modes
 
 The following modes are supported for the `dump` attribute:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ The DSN has to be in the following format:
 
 For further explanations have a look at the [Doctrine documentation](http://doctrine-orm.readthedocs.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url).
 
+You can also specify the buffer size with an option. Add a suffix (KB, MB or GB) to the value for better readability.
+
+Example:
+`slimdump --buffer-size 16MB {DSN} {config-file}`
+
 ## Configuration
 Configuration is stored in XML format somewhere in your filesystem. As a benefit, you could add the configuration to your repository to share a quickstart to your database dump with your coworkers.
 
@@ -90,20 +95,6 @@ Example:
 <slimdump>
   <!-- Dump all users whose usernames begin with foo -->
   <table name="user" dump="full" condition="`username` LIKE 'foo%'" />
-</slimdump>
-```
-
-### Buffer sizes
-
-You may are not able to fully administrate your MySQL database. Often you run into problems with the buffer size on really
-big tables. You can set the buffer size per table. Add a suffix (KB, MB or GB) to the value.
-
-Example:
-```xml
-<?xml version="1.0" ?>
-<slimdump>
-  <!-- Limit the buffer size to 12MB -->
-  <table name="*" dump="full" buffer-size="12MB" />
 </slimdump>
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The DSN has to be in the following format:
 
 For further explanations have a look at the [Doctrine documentation](http://doctrine-orm.readthedocs.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url).
 
-You can also specify the buffer size with an optional cli-option. Add a suffix (KB, MB or GB) to the value for better readability.
+You can also specify the buffer size, which can be useful on shared environments where your `max_allowed_packet` is low.
+Do this by using the optional cli-option `buffer-size`. Add a suffix (KB, MB or GB) to the value for better readability.
 
 Example:
 `slimdump --buffer-size=16MB {DSN} {config-file}`

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ The DSN has to be in the following format:
 
 For further explanations have a look at the [Doctrine documentation](http://doctrine-orm.readthedocs.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url).
 
-You can also specify the buffer size with an option. Add a suffix (KB, MB or GB) to the value for better readability.
+You can also specify the buffer size with an optional cli-option. Add a suffix (KB, MB or GB) to the value for better readability.
 
 Example:
-`slimdump --buffer-size 16MB {DSN} {config-file}`
+`slimdump --buffer-size=16MB {DSN} {config-file}`
 
 ## Configuration
 Configuration is stored in XML format somewhere in your filesystem. As a benefit, you could add the configuration to your repository to share a quickstart to your database dump with your coworkers.

--- a/src/Webfactory/Slimdump/Config/Table.php
+++ b/src/Webfactory/Slimdump/Config/Table.php
@@ -204,6 +204,34 @@ class Table
     }
 
     /**
+     * @return int
+     */
+    public function getBufferSize()
+    {
+        $bufferSize = $this->config->attributes()->{'buffer-size'};
+
+        if ($bufferSize !== null) {
+            preg_match('/^(\d+)(KB|MB|GB)?$/', $bufferSize, $matches);
+            $bufferSize = (int)$matches[1];
+            $bufferFactor = 1;
+
+            switch ($matches[2]) {
+                case 'GB':
+                    $bufferFactor *= 1024;
+                case 'MB':
+                    $bufferFactor *= 1024;
+                case 'KB':
+                    $bufferFactor *= 1024;
+            }
+
+            return $bufferSize * $bufferFactor;
+        } else {
+            // Default 100MB
+            return 100 * 1024 * 1024;
+        }
+    }
+
+    /**
      * @param string $columnName
      *
      * @return Column

--- a/src/Webfactory/Slimdump/Config/Table.php
+++ b/src/Webfactory/Slimdump/Config/Table.php
@@ -204,34 +204,6 @@ class Table
     }
 
     /**
-     * @return int
-     */
-    public function getBufferSize()
-    {
-        $bufferSize = $this->config->attributes()->{'buffer-size'};
-
-        if ($bufferSize !== null) {
-            preg_match('/^(\d+)(KB|MB|GB)?$/', $bufferSize, $matches);
-            $bufferSize = (int)$matches[1];
-            $bufferFactor = 1;
-
-            switch ($matches[2]) {
-                case 'GB':
-                    $bufferFactor *= 1024;
-                case 'MB':
-                    $bufferFactor *= 1024;
-                case 'KB':
-                    $bufferFactor *= 1024;
-            }
-
-            return $bufferSize * $bufferFactor;
-        } else {
-            // Default 100MB
-            return 100 * 1024 * 1024;
-        }
-    }
-
-    /**
      * @param string $columnName
      *
      * @return Column

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -125,7 +125,7 @@ class Dumper
         $this->output->writeln("-- BEGIN DATA $table", OutputInterface::OUTPUT_RAW);
 
         $bufferSize = 0;
-        $max = 100 * 1024 * 1024; // 100 MB
+        $max = $tableConfig->getBufferSize();
         $numRows = $db->fetchColumn("SELECT COUNT(*) FROM `$table`");
 
         if ($numRows == 0) {

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\PDOConnection;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
+use Webfactory\Slimdump\Config\Config;
 use Webfactory\Slimdump\Config\Table;
 
 class Dumper
@@ -13,10 +14,19 @@ class Dumper
     
     /** @var OutputInterface */
     protected $output;
-    
-    public function __construct(OutputInterface $output)
+
+    /** @var integer */
+    protected $bufferSize;
+
+    /**
+     * Dumper constructor.
+     * @param OutputInterface $output
+     * @param int $bufferSize Default buffer size is 100MB
+     */
+    public function __construct(OutputInterface $output, $bufferSize = 104857600)
     {
         $this->output = $output;
+        $this->bufferSize = $bufferSize;
     }
 
     public function exportAsUTF8()
@@ -125,7 +135,7 @@ class Dumper
         $this->output->writeln("-- BEGIN DATA $table", OutputInterface::OUTPUT_RAW);
 
         $bufferSize = 0;
-        $max = $tableConfig->getBufferSize();
+        $max = $this->bufferSize;
         $numRows = $db->fetchColumn("SELECT COUNT(*) FROM `$table`");
 
         if ($numRows == 0) {

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -21,12 +21,12 @@ class Dumper
     /**
      * Dumper constructor.
      * @param OutputInterface $output
-     * @param int $bufferSize Default buffer size is 100MB
+     * @param int|null $bufferSize Default buffer size is 100MB
      */
-    public function __construct(OutputInterface $output, $bufferSize = 104857600)
+    public function __construct(OutputInterface $output, $bufferSize = null)
     {
         $this->output = $output;
-        $this->bufferSize = $bufferSize;
+        $this->bufferSize = $bufferSize ? : 104857600;
     }
 
     public function exportAsUTF8()

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -33,7 +33,7 @@ class SlimdumpCommand extends Command
             ->addOption(
                 'buffer-size',
                 'b',
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'Maximum length of a single SQL statement generated.',
                 '100MB'
             )

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -75,7 +75,10 @@ class SlimdumpCommand extends Command
         $bufferSize = $size;
 
         if ($bufferSize !== null) {
-            preg_match('/^(\d+)(KB|MB|GB)?$/', $bufferSize, $matches);
+            $match = preg_match('/^(\d+)(KB|MB|GB)?$/', $bufferSize, $matches);
+            if ($match === false) {
+                throw new \RuntimeException('The buffer size must be an unsigned integer ending with KB, MB or GB.');
+            }
             $bufferSize = (int)$matches[1];
             $bufferFactor = 1;
 

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -92,9 +92,6 @@ class SlimdumpCommand extends Command
             }
 
             return $bufferSize * $bufferFactor;
-        } else {
-            // Default 100MB
-            return 100 * 1024 * 1024;
         }
     }
 

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -34,7 +34,7 @@ class SlimdumpCommand extends Command
                 'buffer-size',
                 'b',
                 InputOption::VALUE_OPTIONAL,
-                'Maximum buffer for the database connected to',
+                'Maximum length of a single SQL statement generated.',
                 '100MB'
             )
         ;

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -51,7 +51,7 @@ class SlimdumpCommand extends Command
         $db = $this->connect($dsn);
 
         $config = ConfigBuilder::createConfigurationFromConsecutiveFiles($input->getArgument('config'));
-        $this->dump($config, $db, $output, $this->reformatBufferSize($input->getOption('buffer-size')));
+        $this->dump($config, $db, $output, $this->parseBufferSize($input->getOption('buffer-size')));
     }
 
     private function connect($dsn)
@@ -70,7 +70,7 @@ class SlimdumpCommand extends Command
     /**
      * @return int
      */
-    protected function reformatBufferSize($size)
+    protected function parseBufferSize($size)
     {
         $bufferSize = $size;
 

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -33,9 +33,8 @@ class SlimdumpCommand extends Command
             ->addOption(
                 'buffer-size',
                 'b',
-                InputOption::VALUE_REQUIRED,
-                'Maximum length of a single SQL statement generated.',
-                '100MB'
+                InputOption::VALUE_OPTIONAL,
+                'Maximum length of a single SQL statement generated. Defaults to 100MB.'
             )
         ;
     }
@@ -68,7 +67,7 @@ class SlimdumpCommand extends Command
     }
 
     /**
-     * @return int
+     * @return int|null
      */
     protected function parseBufferSize($size)
     {
@@ -93,6 +92,8 @@ class SlimdumpCommand extends Command
 
             return $bufferSize * $bufferFactor;
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
We had some problems inserting some huge tables, so we added a limit for the buffer size.