### PR TITLE
Force PDO Connection for mysqli DSN by 'cleaning' the connection string

### DIFF
--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -3,6 +3,8 @@
 namespace Webfactory\Slimdump;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\DBALException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -56,10 +58,16 @@ class SlimdumpCommand extends Command
     private function connect($dsn)
     {
         try {
-            return \Doctrine\DBAL\DriverManager::getConnection(
-                array('url' => $dsn, 'charset' => 'utf8', 'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver')
+            /**
+             * a dsn string containing mysqli will result in the DriverManager creating a MysqliConnection but we need PDO
+             * @see DriverManager::parseDatabaseUrlScheme()
+             */
+            $mysqliIndependentDsn = str_replace('mysqli://', 'mysql://', $dsn);
+
+            return DriverManager::getConnection(
+                array('url' => $mysqliIndependentDsn, 'charset' => 'utf8', 'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver')
             );
-        } catch (Exception $e) {
+        } catch (DBALException $e) {
             $msg = "Database error: " . $e->getMessage();
             fwrite(STDERR, "$msg\n");
             exit(1);

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -62,7 +62,7 @@ class SlimdumpCommand extends Command
              * a dsn string containing mysqli will result in the DriverManager creating a MysqliConnection but we need PDO
              * @see DriverManager::parseDatabaseUrlScheme()
              */
-            $mysqliIndependentDsn = str_replace('mysqli://', 'mysql://', $dsn);
+            $mysqliIndependentDsn = preg_replace('_^mysqli://_', 'mysql:', $dsn);
 
             return DriverManager::getConnection(
                 array('url' => $mysqliIndependentDsn, 'charset' => 'utf8', 'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver')


### PR DESCRIPTION
I didn't want to give up the parsing of the DSN string by the DriverManager so I chose to replace the 'mysqli://' in the connection string with 'mysql://' if it exists, this way we should always end up with a PDO Connection.

If we would do the parsing ourselves then we could skip the 'url' Parameter in DriverManager::getConnection($params).

Any connection information inside $params['url'] will always precede other parameters, see https://github.com/doctrine/dbal/blob/master/lib/Doctrine/DBAL/DriverManager.php#L400

Fixes #44 

DBAL Docs on creating a Connection: https://www.doctrine-project.org/projects/doctrine-dbal/en/2.7/reference/configuration.html