### PR TITLE
Data containing backslashes is not properly escaped, possibly only when using the "masked" dump type

### DIFF
--- a/src/Webfactory/Slimdump/Config/Table.php
+++ b/src/Webfactory/Slimdump/Config/Table.php
@@ -180,14 +180,14 @@ class Table
             return '""';
         } else {
             if ($column = $this->findColumn($columnName)) {
-                return $db->quote($column->processRowValue($value));
+                return addslashes($db->quote($column->processRowValue($value)));
             }
 
             if ($isBlobColumn) {
                 return $value;
             }
 
-            return $db->quote($value);
+            return addslashes($db->quote($value));
         }
     }
 


### PR DESCRIPTION
fixes the '/' problem in the data export