### PR TITLE
Apply `WHERE` condition when counting the number of rows to export

### DIFF
--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -136,7 +136,7 @@ class Dumper
 
         $bufferSize = 0;
         $max = $this->bufferSize;
-        $numRows = $db->fetchColumn("SELECT COUNT(*) FROM `$table`");
+        $numRows = $db->fetchColumn("SELECT COUNT(*) FROM `$table`".$tableConfig->getCondition());
 
         if ($numRows == 0) {
             // Fail fast: No data to dump.


### PR DESCRIPTION
In our project, it is not possible to count all rows in our biggest table (very bad performances) before exporting a small subset of this table.

We need to apply the same condition as the one in the XML configuration file which for some reason is ignored when estimating the number of rows that will be exported.