### PR TITLE
Fix Travis CI about implode function usage

### DIFF
--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -223,7 +223,7 @@ class Dumper
      */
     protected function insertValuesStatement($table, $cols)
     {
-        return "INSERT INTO `$table` (`" . implode(array_keys($cols), '`, `') . "`) VALUES ";
+        return "INSERT INTO `$table` (`" . implode('`, `', array_keys($cols)) . "`) VALUES ";
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Fix Travis CI build. And it's about changing `implode` function usage.

The deprecated message about `implode` function is as follows:

```
1) Webfactory\Slimdump\Database\DumperTest::testDumpDataWithFullConfiguration
implode(): Passing glue string after array is deprecated. Swap the parameters
/home/travis/build/webfactory/slimdump/src/Webfactory/Slimdump/Database/Dumper.php:226
```