### PR TITLE
Using PSR-4 autoloading instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "fzaninotto/faker": "^1.6"
     },
     "autoload": {
-        "psr-0": {
-            "Webfactory": "src/"
+        "psr-4": {
+            "Webfactory\\Slimdump\\": "src/Webfactory/Slimdump"
         }
     }
 }


### PR DESCRIPTION
# Changed log
- The `PSR-0` autoloading is deprecated. Using the `PSR-4` approach instead.