### PR TITLE
Add GitHub action badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![webfactory Logo](https://www.webfactory.de/bundles/webfactorytwiglayout/img/logo.png) slimdump
 ========
 
-[![Build Status](https://travis-ci.org/webfactory/slimdump.svg?branch=master)](https://travis-ci.org/webfactory/slimdump)
+[![Build Status](https://github.com/webfactory/slimdump/workflows/Run%20Tests/badge.svg)](https://github.com/webfactory/slimdump/actions)
 [![Coverage Status](https://coveralls.io/repos/webfactory/slimdump/badge.svg?branch=master&service=github)](https://coveralls.io/github/webfactory/slimdump?branch=master)
 
 `slimdump` is a little tool to help you creating configurable dumps of large MySQL-databases. It works off one or several configuration files. For every table you specify, it can dump only the schema (`CREATE TABLE ...` statement), full table data, data without blobs and more.
@@ -10,7 +10,7 @@
 
 We created `slimdump` because we often need to dump parts of MySQL databases in a convenient and reproducible way. Also, when you need to analyze problems with data from your production databases, you might want to pull only relevant parts of data and also hide personal data (user names, for example).
 
-`mysqldump` is a great tool, probably much more proven when it comes to edge cases and with a lot of switches. But there is no easy way to create a simple configuration file that describes a particular type of dump (e. g. a subset of your tables) and share it with your co-workers. Let alone dumping tables and omitting BLOB type columns. 
+`mysqldump` is a great tool, probably much more proven when it comes to edge cases and with a lot of switches. But there is no easy way to create a simple configuration file that describes a particular type of dump (e. g. a subset of your tables) and share it with your co-workers. Let alone dumping tables and omitting BLOB type columns.
 
 ## Installation
 
@@ -55,28 +55,28 @@ Example:
 <slimdump>
   <!-- Create a full dump (schema + data) of "some_table" -->
   <table name="some_table" dump="full" />
-  
+
   <!-- Dump the "media" table, omit BLOB fields. -->
   <table name="media" dump="noblob" />
-  
+
   <!-- Dump the "user" table, hide names and email addresses. -->
   <table name="user" dump="full">
       <column name="username" dump="masked" />
       <column name="email" dump="masked" />
       <column name="password" dump="replace" replacement="test" />
   </table>
-  
+
   <!-- Dump the "document" table but do not pass the "AUTO_INCREMENT" parameter to the SQL query.
        Instead start to increment from the beginning -->
   <table name="document" dump="full" keep-auto-increment="false" />
-  
-  <!-- 
-    Trigger handling: 
-    
+
+  <!--
+    Trigger handling:
+
     By default, CREATE TRIGGER statements will be dumped for all tables, but the "DEFINER=..."
     clause will be removed to make it easier to re-import the database e. g. in development
-    environments. 
-    
+    environments.
+
     You can change this by setting 'dump-triggers' to one of:
         - 'false' or 'none': Do not dump triggers at all
         - 'true' or 'no-definer': Dump trigger creation statement but remove DEFINER=... clause
@@ -145,13 +145,13 @@ Example:
 <slimdump>
   <!-- Default: dump all tables -->
   <table name="*" dump="full" />
-  
+
   <!-- Dump all tables beginning with "a_" as schema -->
   <table name="a_*" dump="schema" />
-  
+
   <!-- Dump "big_blob_table" without blobs -->
   <table name="big_blob_table" dump="noblob" />
-  
+
   <!-- Do not dump any tables ending with "_test" -->
   <table name="*_test" dump="none" />
 </slimdump>
@@ -161,7 +161,7 @@ This is a valid configuration. If more than one instruction matches a specific t
 ### Replacements
 
 You probably don't want to use any personal data from your database. Therefore, slimdump allows you to replace data on
-column level - a great instrument not only for General Data Protection Regulation (GDPR) compliance. 
+column level - a great instrument not only for General Data Protection Regulation (GDPR) compliance.
 
 The most simple replacement is a static one:
 
@@ -176,10 +176,10 @@ The most simple replacement is a static one:
 
 This replaces the password values of all users with "test" (in clear text - but for sure you have [some sort of hashing in place](https://secure.php.net/manual/en/faq.passwords.php), do you?).
 
-To achieve realistically sounding dummy data, slimdump also allows [basic Faker formatters](https://github.com/fzaninotto/Faker/#formatters). 
+To achieve realistically sounding dummy data, slimdump also allows [basic Faker formatters](https://github.com/fzaninotto/Faker/#formatters).
 You can use every Faker formatter which needs no arguments and modifiers such as `unique` (just seperate the modifier
 with an object operator (`->`), as you would do in PHP). This is especially useful if your table has a unique constraint
-on a column containing personal information, like the email address. 
+on a column containing personal information, like the email address.
 
 ```xml
 <?xml version="1.0" ?>
@@ -208,7 +208,7 @@ Currently only MySQL is supported. But feel free to port it to the database of y
 
 ### Tests
 
-You can execute the phpunit-tests by calling `vendor/bin/phpunit`. 
+You can execute the phpunit-tests by calling `vendor/bin/phpunit`.
 
 ## Credits, Copyright and License
 


### PR DESCRIPTION
# Changed log
- According to the useful [reference](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository), adding the GitHub actions badge to replace Travis CI build status badge.