### PR TITLE
Add option to write INSERT statements to one single line (Case 109924)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,24 @@ The DSN has to be in the following format:
 
 For further explanations have a look at the [Doctrine documentation](http://doctrine-orm.readthedocs.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url).
 
+### Optional parameters
+
+#### buffer-size
+
 You can also specify the buffer size, which can be useful on shared environments where your `max_allowed_packet` is low.
 Do this by using the optional cli-option `buffer-size`. Add a suffix (KB, MB or GB) to the value for better readability.
 
 Example:
 `slimdump --buffer-size=16MB {DSN} {config-file}`
+
+#### single-line-insert-statements
+
+If you have tables with a large number of rows to dump and you are not planning to keep your dumps under version
+control, you might consider writing each `INSERT INTO`-statement to a single line instead of one line per row. You can
+do this by using the cli-parameter `single-line-insert-statements`. This can speed up the import significantly.
+
+Example:
+`slimdump --single-line-insert-statements {DSN} {config-file}`
 
 ## Configuration
 Configuration is stored in XML format somewhere in your filesystem. As a benefit, you could add the configuration to your repository to share a quickstart to your database dump with your coworkers.

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -19,6 +19,9 @@ class Dumper
     /** @var int */
     protected $bufferSize;
 
+    /** @var bool */
+    protected $singleLineInsertStatements = false;
+
     /**
      * @param OutputInterface $output
      * @param int|null        $bufferSize Default buffer size is 100MB
@@ -27,6 +30,11 @@ class Dumper
     {
         $this->output = $output;
         $this->bufferSize = $bufferSize ?: 104857600;
+    }
+
+    public function setSingleLineInsertStatements(bool $singleLineInsertStatements): void
+    {
+        $this->singleLineInsertStatements = $singleLineInsertStatements;
     }
 
     public function exportAsUTF8()
@@ -194,7 +202,12 @@ class Dumper
             }
 
             $firstCol = true;
-            $this->output->write("\n(", false, OutputInterface::OUTPUT_RAW);
+
+            if (!$this->singleLineInsertStatements) {
+                $this->output->write("\n", false, OutputInterface::OUTPUT_RAW);
+            }
+
+            $this->output->write("(", false, OutputInterface::OUTPUT_RAW);
 
             foreach ($row as $name => $value) {
                 $isBlobColumn = $this->isBlob($name, $cols);

--- a/src/Webfactory/Slimdump/DumpTask.php
+++ b/src/Webfactory/Slimdump/DumpTask.php
@@ -34,18 +34,25 @@ final class DumpTask
     private $noProgress;
 
     /**
+     * @var bool
+     */
+    private $singleLineInsertStatements;
+
+    /**
      * @param string          $dsn
      * @param string[]        $configFiles
      * @param bool            $noProgress
+     * @param bool            $singleLineInsertStatements
      * @param OutputInterface $output
      *
      * @throws DBALException
      */
-    public function __construct($dsn, array $configFiles, bool $noProgress, OutputInterface $output)
+    public function __construct($dsn, array $configFiles, bool $noProgress, bool $singleLineInsertStatements, OutputInterface $output)
     {
         $mysqliIndependentDsn = preg_replace('_^mysqli:_', 'mysql:', $dsn);
 
         $this->noProgress = $noProgress;
+        $this->singleLineInsertStatements = $singleLineInsertStatements;
         $this->output = $output;
         $this->config = ConfigBuilder::createConfigurationFromConsecutiveFiles($configFiles);
         $this->db = DriverManager::getConnection(
@@ -56,6 +63,7 @@ final class DumpTask
     public function dump()
     {
         $dumper = new Dumper($this->output);
+        $dumper->setSingleLineInsertStatements($this->singleLineInsertStatements);
         $dumper->exportAsUTF8();
         $dumper->disableForeignKeys();
 

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -37,6 +37,12 @@ final class SlimdumpCommand extends Command
                 '',
                 InputOption::VALUE_NONE,
                 'Don\'t print progress information while dumping tables.'
+            )
+            ->addOption(
+                'single-line-insert-statements',
+                '',
+                InputOption::VALUE_NONE,
+                'Write each whole INSERT INTO statement into one single line instead of creating a new line for each row.'
             );
     }
 
@@ -53,12 +59,13 @@ final class SlimdumpCommand extends Command
         $dsn = $input->getArgument('dsn');
         $configFiles = $input->getArgument('config');
         $noProgress = $input->getOption('no-progress') ? true : false;
+        $singleLineInsertStatements = $input->getOption('single-line-insert-statements') ? true : false;
 
         if ('-' === $dsn) {
             $dsn = getenv('MYSQL_DSN');
         }
 
-        $dumptask = new DumpTask($dsn, $configFiles, $noProgress, $output);
+        $dumptask = new DumpTask($dsn, $configFiles, $noProgress, $singleLineInsertStatements, $output);
         $dumptask->dump();
         
         return 0;


### PR DESCRIPTION
We have noticed that extended inserts with a large amount of data can run significantly faster if they do not contain newlines ("`\n`"). To make this behavior available in Slimdump, we introduce the `--single-line-insert-statements` option.

To ensure BC, this option defaults to FALSE.