### PR TITLE
Allow calling faker methods with arguments

### DIFF
--- a/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
+++ b/test/Webfactory/Slimdump/Config/FakerReplacerTest.php
@@ -52,6 +52,10 @@ class FakerReplacerTest extends TestCase
         return [
             [FakerReplacer::PREFIX.'firstname'], // original faker property
             [FakerReplacer::PREFIX.'lastname'], // original faker property
+            [FakerReplacer::PREFIX.'randomDigitNot:0'], // faker method with single argument
+            [FakerReplacer::PREFIX.'numberBetween:1,20'], // faker method with two arguments
+            [FakerReplacer::PREFIX.'shuffle:"hello world"'], // faker property with single argument
+            [FakerReplacer::PREFIX.'numerify:"Helo ###"'], // faker property with single argument
         ];
     }
 
@@ -65,6 +69,10 @@ class FakerReplacerTest extends TestCase
         return [
             ['firstname'], // original faker property
             ['lastname'], // original faker property
+            ['randomDigitNot:0'], // original faker property
+            ['numberBetween:1,20'], // original faker property
+            ['shuffle:"hello world"'], // original faker property
+            ['numerify:"Helo ###"'], // original faker property
         ];
     }
 }


### PR DESCRIPTION
This PR adds the ability to call more complex faker methods.

It follows an easy convention: `FAKER_methodName:arguments`
The arguments of the faker method can be separated by a comma.

Examples:

```x,ö
<?xml version="1.0" ?>
<slimdump>
    <table name="users" dump="full">
        <column name="username" dump="replace" replacement="FAKER_word" />
        <column name="password" dump="replace" replacement="test" />
        <column name="amount" dump="replace" replacement="FAKER_numberBetween:1,100" />
        <column name="lastname" dump="replace" replacement="FAKER_numerify:'Helo ###'" />
        <column name="email" dump="replace" replacement="FAKER_unique->randomDigitNot:0" />
    </table>
</slimdump>
```