### PR TITLE
Repair --buffer-size parameter

### DIFF
--- a/src/Webfactory/Slimdump/DumpTask.php
+++ b/src/Webfactory/Slimdump/DumpTask.php
@@ -8,7 +8,6 @@ use Webfactory\Slimdump\Config\Config;
 use Webfactory\Slimdump\Database\Dumper;
 use Doctrine\DBAL\Connection;
 
-
 final class DumpTask
 {
     /**

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -83,26 +83,26 @@ final class SlimdumpCommand extends Command
 
     private function parseBufferSize($bufferSize): ?int
     {
-        if ($bufferSize !== null) {
-            $match = preg_match('/^(\d+)(KB|MB|GB)?$/', $bufferSize, $matches);
-            if ($match === false) {
-                throw new \RuntimeException('The buffer size must be an unsigned integer, optionally ending with KB, MB or GB.');
-            }
-            $bufferSize = (int)$matches[1];
-            $bufferFactor = 1;
-
-            switch ($matches[2]) {
-                case 'GB':
-                    $bufferFactor *= 1024;
-                case 'MB':
-                    $bufferFactor *= 1024;
-                case 'KB':
-                    $bufferFactor *= 1024;
-            }
-
-            return $bufferSize * $bufferFactor;
+        if ($bufferSize === null) {
+            return null;
         }
 
-        return null;
+        $match = preg_match('/^(\d+)(KB|MB|GB)?$/', $bufferSize, $matches);
+        if ($match === false) {
+            throw new \RuntimeException('The buffer size must be an unsigned integer, optionally ending with KB, MB or GB.');
+        }
+        $bufferSize = (int)$matches[1];
+        $bufferFactor = 1;
+
+        switch ($matches[2]) {
+            case 'GB':
+                $bufferFactor *= 1024;
+            case 'MB':
+                $bufferFactor *= 1024;
+            case 'KB':
+                $bufferFactor *= 1024;
+        }
+
+        return $bufferSize * $bufferFactor;
     }
 }

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -88,7 +88,7 @@ final class SlimdumpCommand extends Command
         }
 
         $match = preg_match('/^(\d+)(KB|MB|GB)?$/', $bufferSize, $matches);
-        if ($match === false) {
+        if ($match === false || $match === 0) {
             throw new \RuntimeException('The buffer size must be an unsigned integer, optionally ending with KB, MB or GB.');
         }
         $bufferSize = (int)$matches[1];

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -81,7 +81,7 @@ final class SlimdumpCommand extends Command
         return 0;
     }
 
-    private function parseBufferSize($bufferSize): ?int
+    private function parseBufferSize(?string $bufferSize): ?int
     {
         if ($bufferSize === null) {
             return null;


### PR DESCRIPTION
As pointed out in #64, the feature of controlling the buffer size (introduced in [f227b13..141d02b](https://github.com/webfactory/slimdump/compare/f227b133cea2296e4399a4307b39be2f60ef0027..141d02bca66c648aa1003face6d0a28ddac29835)) got lost during the merge of [f227b13..fe193d0](https://github.com/webfactory/slimdump/compare/f227b133cea2296e4399a4307b39be2f60ef0027..fe193d0b6ecf4a5fe312e0d08019a694b30d421f). This PR reintroduces the lost changes, and it seems to work fine.