### PR TITLE
Print a warning when the number of rows dumped does not match the expected count

### DIFF
--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -183,6 +183,7 @@ class Dumper
         /** @var PDOConnection $wrappedConnection */
         $wrappedConnection = $db->getWrappedConnection();
         $wrappedConnection->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+        $actualRows = 0;
 
         foreach ($db->query($s) as $row) {
             $b = $this->rowLengthEstimate($row);
@@ -222,6 +223,8 @@ class Dumper
             if (null !== $progress) {
                 $progress->advance();
             }
+
+            ++$actualRows;
         }
 
         if (null !== $progress) {
@@ -230,6 +233,10 @@ class Dumper
             if ($this->output instanceof ConsoleOutput) {
                 $this->output->getErrorOutput()->write("\n"); // write a newline after the progressbar.
             }
+        }
+
+        if ($actualRows !== $numRows) {
+            $this->output->getErrorOutput()->writeln(sprintf('<error>Expected %d rows, actually processed %d – verify results!</error>', $numRows, $actualRows));
         }
 
         $wrappedConnection->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);


### PR DESCRIPTION
This might be a sufficient mitigation for #84.

Might give false alarms to users that are not really affected by #84, but who try to `slimpdump` tables while rows are being added and/or deleted in between counting and dumping the rows (currently, no transaction support in `slimdump`).
