### PR TITLE
Disable MySQL's `max_execution_time` timeout if set

### DIFF
--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -71,7 +71,7 @@ final class SlimdumpCommand extends Command
 
         $maxExecutionTimeInfo = $connection->fetchAssociative('SHOW VARIABLES LIKE "max_execution_time"');
 
-        if ($maxExecutionTimeInfo && $maxExecutionTimeInfo['Value'] != 0) {
+        if ($maxExecutionTimeInfo && 0 != $maxExecutionTimeInfo['Value']) {
             $connection->executeQuery('SET SESSION max_execution_time = 0');
             if ($output instanceof ConsoleOutputInterface) {
                 $output->getErrorOutput()->writeln('<info>The MySQL "max_execution_time" timeout setting has been disabled for the current database connection.</info>');


### PR DESCRIPTION
A possible mitigation for #84, but maybe also an addition helpful in general:

Since dumping (large) tables might take some time, it might be reasonable and helpful to the user if we disable the [`max_execution_time` MySQL timeout setting](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_max_execution_time) for the current connection.