### PR TITLE
Führe GitHub Actions Workflows mit Ubuntu 20.04 aus

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -12,7 +12,7 @@ env:
 jobs:
     composer-require-checker:
         name: Check missing composer requirements
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         steps:
             -   uses: actions/checkout@v2
             -   name: Konfiguriere PHP-Version und -Einstellungen im Worker-Node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Build .phar on release
 
 jobs:
     build_phar:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         steps:
             -   uses: actions/checkout@v1
             -   name: Install PHIVE

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     PHPUnit:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-20.04
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
Der für uns wesentliche Unterschied sollte die Verwendung von MySQL 8 sein. Auf diese Weise können wir testen, ob wir vorwärtskompatibel sind.
