### PR TITLE
Extract OutputFormatDriverInterface and clean up its method signatures by preferring passing Schema Asset objects

### DIFF
--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -102,7 +102,7 @@ class Dumper
             }
             $first = false;
 
-            $s .= $tableConfig->getSelectExpression($columnName, self::isBlob($asset->getColumn($columnName))) . " AS `$columnName`";
+            $s .= $tableConfig->getSelectExpression($columnName, self::isBlob($asset->getColumn($columnName)))." AS `$columnName`";
         }
         $s .= " FROM `$table`";
         $s .= $tableConfig->getCondition();
@@ -162,7 +162,7 @@ class Dumper
     {
         $type = $column->getType();
 
-        return $type instanceof BlobType || $type instanceof  BinaryType;
+        return $type instanceof BlobType || $type instanceof BinaryType;
     }
 
     private function keepalive()

--- a/src/Webfactory/Slimdump/Database/OutputFormatDriverInterface.php
+++ b/src/Webfactory/Slimdump/Database/OutputFormatDriverInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Webfactory\Slimdump\Database;
+
+use Doctrine\DBAL\Schema;
+use Webfactory\Slimdump\Config\Table;
+
+interface OutputFormatDriverInterface
+{
+    /**
+     * Called once at the beginning of the entire slimdump run.
+     */
+    public function beginDump(): void;
+
+    /**
+     * Called once at the very end of the entire slimdump run.
+     */
+    public function endDump(): void;
+
+    /**
+     * Called to dump the structural information for a single table
+     */
+    public function dumpTableStructure(Schema\Table $asset, Table $config): void;
+
+    /**
+     * Called to dump view definitions
+     */
+    public function dumpViewDefinition(Schema\View $asset, Table $config): void;
+
+    /**
+     * Called at the beginning when dumping data for a single table
+     */
+    public function beginTableDataDump(Schema\Table $asset, Table $config): void;
+
+    /**
+     * Called for every table data row
+     */
+    public function dumpTableRow(array $row, Schema\Table $asset, Table $config): void;
+
+    /**
+     * Called at the end after dumping data for a single table
+     */
+    public function endTableDataDump(Schema\Table $asset, Table $config): void;
+}

--- a/src/Webfactory/Slimdump/Database/OutputFormatDriverInterface.php
+++ b/src/Webfactory/Slimdump/Database/OutputFormatDriverInterface.php
@@ -18,27 +18,27 @@ interface OutputFormatDriverInterface
     public function endDump(): void;
 
     /**
-     * Called to dump the structural information for a single table
+     * Called to dump the structural information for a single table.
      */
     public function dumpTableStructure(Schema\Table $asset, Table $config): void;
 
     /**
-     * Called to dump view definitions
+     * Called to dump view definitions.
      */
     public function dumpViewDefinition(Schema\View $asset, Table $config): void;
 
     /**
-     * Called at the beginning when dumping data for a single table
+     * Called at the beginning when dumping data for a single table.
      */
     public function beginTableDataDump(Schema\Table $asset, Table $config): void;
 
     /**
-     * Called for every table data row
+     * Called for every table data row.
      */
     public function dumpTableRow(array $row, Schema\Table $asset, Table $config): void;
 
     /**
-     * Called at the end after dumping data for a single table
+     * Called at the end after dumping data for a single table.
      */
     public function endTableDataDump(Schema\Table $asset, Table $config): void;
 }

--- a/src/Webfactory/Slimdump/SlimdumpCommand.php
+++ b/src/Webfactory/Slimdump/SlimdumpCommand.php
@@ -68,6 +68,7 @@ final class SlimdumpCommand extends Command
         $connection = DriverManager::getConnection(
             ['url' => $mysqliIndependentDsn, 'charset' => 'utf8', 'driverClass' => PDOMySqlDriver::class]
         );
+        $connection->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
 
         $maxExecutionTimeInfo = $connection->fetchAssociative('SHOW VARIABLES LIKE "max_execution_time"');
 


### PR DESCRIPTION
This PR tweaks the new `SqlDumper` class from #88 a bit and introduces a dedicated interface for it. Also, it prefers using the Schema Tool API instead of passing around an array of column names.