### PR TITLE
Implement CSV output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ do this by using the cli-parameter `single-line-insert-statements`. This can spe
 Example:
 `slimdump --single-line-insert-statements {DSN} {config-file}`
 
+#### output-csv
+
+This option turns on the CSV (comma separated values) output mode. It must be given the path to a directory where `.csv` files will be created. The files are named according to tables, e. g. `my_table.csv`.
+
+CSV files contain only data. They are not created for views, triggers, or tables dumped with the `schema` dump mode. Also, no files will be created for empty tables.
+
+Since this output format needs to write to different files for different tables, redirecting `stdout` output (as can be done for the default MySQL SQL mode) is not possible.
+
+**Experimental Feature** CSV support is a new, [experimental feature](https://github.com/webfactory/slimdump/pull/92). The output formatting may change at any time.  
+
 ## Configuration
 Configuration is stored in XML format somewhere in your filesystem. As a benefit, you could add the configuration to your repository to share a quickstart to your database dump with your coworkers.
 
@@ -254,4 +264,4 @@ If you're a developer looking for new challenges, we'd like to hear from you! Ot
 - <https://www.webfactory.de>
 - <https://twitter.com/webfactory>
 
-Copyright 2014-2020 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).
+Copyright 2014-2022 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).

--- a/src/Webfactory/Slimdump/Database/CsvOutputFormatDriver.php
+++ b/src/Webfactory/Slimdump/Database/CsvOutputFormatDriver.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Webfactory\Slimdump\Database;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema;
+use Symfony\Component\Console\Output\OutputInterface;
+use Webfactory\Slimdump\Config\Table;
+
+class CsvOutputFormatDriver implements OutputFormatDriverInterface
+{
+    /** @var OutputInterface */
+    private $output;
+
+    /** @var Connection */
+    private $db;
+
+    public function __construct(OutputInterface $output, Connection $db)
+    {
+        $this->output = $output;
+        $this->db = $db;
+    }
+
+    public function dumpTableStructure(Schema\Table $asset, Table $config): void
+    {
+        $cols = $this->cols($asset->getName());
+
+        $this->output->writeln(implode(';', $cols), OutputInterface::OUTPUT_RAW);
+    }
+
+    public function dumpTableRow(array $row, Schema\Table $asset, Table $config): void
+    {
+        $firstCol = true;
+        foreach ($row as $columnName => $value) {
+            $isBlobColumn = Dumper::isBlob($asset->getColumn($columnName));
+
+            if (!$firstCol) {
+                $this->output->write(';', false, OutputInterface::OUTPUT_RAW);
+            }
+
+            $this->output->write($this->getStringForInsertStatement($columnName, $config, $value, $isBlobColumn), false, OutputInterface::OUTPUT_RAW);
+            $firstCol = false;
+        }
+
+        $this->output->write("\n", false, OutputInterface::OUTPUT_RAW);
+    }
+
+    private function cols(string $tableName): array
+    {
+        $c = [];
+        foreach ($this->db->fetchAll("SHOW COLUMNS FROM `$tableName`") as $row) {
+            $c[] = $row['Field'];
+        }
+
+        return $c;
+    }
+
+    private function getStringForInsertStatement(string $columnName, Table $config, ?string $value, bool $isBlobColumn): string
+    {
+        if (null === $value || '' === $value) {
+            return '';
+        }
+
+        if ($column = $config->findColumn($columnName)) {
+            return $this->db->quote($column->processRowValue($value));
+        }
+
+        if ($isBlobColumn) {
+            return $value;
+        }
+
+        return $this->db->quote($value);
+    }
+
+    public function beginDump(): void
+    {
+    }
+
+    public function endDump(): void
+    {
+    }
+
+    public function dumpViewDefinition(Schema\View $asset, Table $config): void
+    {
+    }
+
+    public function beginTableDataDump(Schema\Table $asset, Table $config): void
+    {
+    }
+
+    public function endTableDataDump(Schema\Table $asset, Table $config): void
+    {
+    }
+}

--- a/src/Webfactory/Slimdump/Database/CsvOutputFormatDriver.php
+++ b/src/Webfactory/Slimdump/Database/CsvOutputFormatDriver.php
@@ -4,6 +4,7 @@ namespace Webfactory\Slimdump\Database;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Schema;
+use InvalidArgumentException;
 use Webfactory\Slimdump\Config\Table;
 
 class CsvOutputFormatDriver implements OutputFormatDriverInterface
@@ -31,7 +32,7 @@ class CsvOutputFormatDriver implements OutputFormatDriverInterface
     public function __construct(string $directory, Connection $connection)
     {
         if (!is_dir($directory) || !is_writable($directory)) {
-            throw new \InvalidArgumentException(sprintf('The directoy "%s" does not exist or is not writeable', $directory));
+            throw new InvalidArgumentException(sprintf('The directoy "%s" does not exist or is not writeable', $directory));
         }
 
         $this->directory = $directory;
@@ -53,7 +54,7 @@ class CsvOutputFormatDriver implements OutputFormatDriverInterface
     public function beginTableDataDump(Schema\Table $asset, Table $config): void
     {
         $this->firstLine = true;
-        $this->outputFile = fopen($this->directory.DIRECTORY_SEPARATOR.$asset->getName().'.csv', 'w');
+        $this->outputFile = fopen($this->directory.\DIRECTORY_SEPARATOR.$asset->getName().'.csv', 'w');
     }
 
     public function endTableDataDump(Schema\Table $asset, Table $config): void


### PR DESCRIPTION
This PR implements a new output mode for CSV files.

The new command option `--output-csv=...` enables CSV output mode, and must be given the path to a directory. The output mode will create `.csv` files in the given directory, named according to the dumped tables.

This output format does not support output redirection from `stdout` as the default MySQL SQL format does.

CSV files will be created only for tables that contain data. In other words, `schema` type dumps will skip the table in question. Also, dumping views/triggers makes no sense for CSV files, they will be skipped as well.

How to best write binary (BLOB) data and/or NULL values in CSV files is probably highly controversial. For now, we'll just go with the [`0x...` hex literals supported by MySQL](https://dev.mysql.com/doc/refman/8.0/en/hexadecimal-literals.html). Maybe having binary data in CSV files is not a sane idea in the first place.

Co-authored-by: Matthias Pigulla <mp@webfactory.de>