### PR TITLE
Update actions/cache to v3

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -21,7 +21,7 @@ jobs:
                     tools: composer:v2
             -   uses: actions/checkout@v3
             -   name: Cache Composer Dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: vendor/
                     key: composer-${{ env.PHP_VERSION }}-${{ hashFiles('composer.*') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
                     tools: composer:v2
             -   uses: actions/checkout@v3
             -   name: Cache Composer Dependencies
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: vendor/
                     key: composer-${{ matrix.php }}-${{ hashFiles('composer.*') }}


### PR DESCRIPTION
This addresses the deprecation described at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
