### PR TITLE
Dump TRIGGER definitions _after_ data

### DIFF
--- a/src/Webfactory/Slimdump/Database/CsvOutputFormatDriver.php
+++ b/src/Webfactory/Slimdump/Database/CsvOutputFormatDriver.php
@@ -75,4 +75,8 @@ class CsvOutputFormatDriver implements OutputFormatDriverInterface
 
         fputcsv($this->outputFile, $row);
     }
+
+    public function dumpTriggerDefinition(Schema\Table $asset, Table $config): void
+    {
+    }
 }

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -77,11 +77,20 @@ class Dumper
         if ($config->isDataDumpRequired()) {
             $this->dumpData($asset, $config);
         }
+
+        if ($config->isTriggerDumpRequired()) {
+            $this->dumpTriggers($asset, $config);
+        }
     }
 
     private function dumpView(Schema\View $asset, Table $config): void
     {
         $this->outputFormatDriver->dumpViewDefinition($asset, $config);
+    }
+
+    private function dumpTriggers(Schema\Table $asset, Table $config): void
+    {
+        $this->outputFormatDriver->dumpTriggerDefinition($asset, $config);
     }
 
     private function dumpData(Schema\Table $asset, Table $tableConfig): void

--- a/src/Webfactory/Slimdump/Database/MysqlOutputFormatDriver.php
+++ b/src/Webfactory/Slimdump/Database/MysqlOutputFormatDriver.php
@@ -60,23 +60,19 @@ class MysqlOutputFormatDriver implements OutputFormatDriverInterface
         }
 
         $this->output->writeln($tableCreationCommand.";\n", OutputInterface::OUTPUT_RAW);
-
-        if ($config->isTriggerDumpRequired()) {
-            $this->dumpTriggers($tableName, $config->getDumpTriggersLevel());
-        }
     }
 
-    /**
-     * @param int $level One of the Table::TRIGGER_* constants
-     */
-    private function dumpTriggers(string $tableName, int $level = Table::DEFINER_NO_DEFINER): void
+    public function dumpTriggerDefinition(Schema\Table $asset, Table $config): void
     {
+        $tableName = $asset->getName();
+
         $triggers = $this->db->fetchAll(sprintf('SHOW TRIGGERS LIKE %s', $this->db->quote($tableName)));
 
         if (!$triggers) {
             return;
         }
 
+        $level = $config->getDumpTriggersLevel();
         $this->output->writeln("-- BEGIN TRIGGERS $tableName", OutputInterface::OUTPUT_RAW);
 
         $this->output->writeln("DELIMITER ;;\n");

--- a/src/Webfactory/Slimdump/Database/OutputFormatDriverInterface.php
+++ b/src/Webfactory/Slimdump/Database/OutputFormatDriverInterface.php
@@ -28,6 +28,11 @@ interface OutputFormatDriverInterface
     public function dumpViewDefinition(Schema\View $asset, Table $config): void;
 
     /**
+     * Called to dump trigger definitions.
+     */
+    public function dumpTriggerDefinition(Schema\Table $asset, Table $config): void;
+
+    /**
      * Called at the beginning when dumping data for a single table.
      */
     public function beginTableDataDump(Schema\Table $asset, Table $config): void;


### PR DESCRIPTION
When the new CSV output mode with the concept of "output drivers" was added in #92, dumping `TRIGGER` definitions was made an implementation detail of the MySQL output driver. This caused `TRIGGER` definitions to be dumped right after the `CREATE TABLE ...` commands, before the actual data `INSERT` statements.

This potentially breaks the generated SQL files, since a newly created trigger may be relevant for the subsequent `INSERT` statements; however, MySQL requires that tables used in the trigger are also included in the `LOCK TABLES` statements.

The aim of this PR is to revert that change, i. e. to dump trigger definitions for a table _after_ the data insert statements for it.

I think it is not necessary to move all trigger definitions to the very end of the output – that is, after _all_ tables have been created and filled with data: A trigger depends on insert/update/deletes for a particular table and is executed only on these events. So, it is not a problem if a trigger refers to a table that has not been created/loaded yet as long as the trigger is not run (and avoiding to run it is the aim of this PR).

