### PR TITLE
Fix: Use configured replacements when dumping table rows in CSV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/
+tmp/
 tools/
 slimdump.phar
 .phpunit.cache

--- a/src/Webfactory/Slimdump/Database/CsvOutputFormatDriver.php
+++ b/src/Webfactory/Slimdump/Database/CsvOutputFormatDriver.php
@@ -73,6 +73,12 @@ class CsvOutputFormatDriver implements OutputFormatDriverInterface
             $this->firstLine = false;
         }
 
+        foreach ($row as $columnName => $value) {
+            if ($column = $config->findColumn($columnName)) {
+                $row[$columnName] = $column->processRowValue($value);
+            }
+        }
+
         fputcsv($this->outputFile, $row);
     }
 

--- a/test/Webfactory/Slimdump/Database/CsvOutputFormatDriverTest.php
+++ b/test/Webfactory/Slimdump/Database/CsvOutputFormatDriverTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Webfactory\Slimdump\Database;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Webfactory\Slimdump\Config\Table;
+
+final class CsvOutputFormatDriverTest extends TestCase
+{
+    private const OUTPUT_DIRECTORY = __DIR__ . '/../../../../tmp';
+
+    private CsvOutputFormatDriver $driver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->driver = new CsvOutputFormatDriver(self::OUTPUT_DIRECTORY, $this->createMock(Connection::class));
+    }
+
+    /**
+     * @param array<string, string> $tableRow
+     */
+    #[Test]
+    #[DataProvider('provideDataFor_dumpTableRow')]
+    public function dumpTableRow(string $tableConfigAsXml, array $tableRow, string $expectedValue): void
+    {
+        $csvData = $this->dumpTableAsCsv($tableConfigAsXml, $tableRow);
+
+        $this->assertSame($expectedValue, $csvData[1][0]);
+    }
+
+    public static function provideDataFor_dumpTableRow(): \Generator
+    {
+        yield 'can dump row as is' => [
+            '<table dump="full" />',
+            ['my-column' => 'my-original-value'],
+            'my-original-value',
+        ];
+
+        yield 'can dump with configured replacement' => [
+            '<table dump="full"><column name="my-column" dump="replace" replacement="my-replacing-value"/></table>',
+            ['my-column' => 'my-original-value'],
+            'my-replacing-value',
+        ];
+    }
+
+    /**
+     * @param array<string, string> $tableRow
+     * @return array<int, array<string>> the dumped CSV data as array of rows, each row being an array of columns
+     */
+    private function dumpTableAsCsv(string $tableConfigAsXml, array $tableRow): array
+    {
+        $tableSchema = new \Doctrine\DBAL\Schema\Table('my-table');
+        $tableConfig = new Table(
+            new \SimpleXMLElement($tableConfigAsXml)
+        );
+
+        $this->driver->beginTableDataDump($tableSchema, $tableConfig);
+        $this->driver->dumpTableRow($tableRow, $tableSchema, $tableConfig);
+        $this->driver->endTableDataDump($tableSchema, $tableConfig);
+
+        $outputFile = self::OUTPUT_DIRECTORY . '/my-table.csv';
+        $this->assertFileExists($outputFile);
+
+        return array_map('str_getcsv', file($outputFile));
+    }
+}


### PR DESCRIPTION
- **Test CsvOutputFormatDriver->dumpTableRow()**
- **Use configured replacements when dumping table rows in CSV**
