### PR TITLE
Update actions used in GHA workflows

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -20,9 +20,9 @@ jobs:
                     php-version: ${{ env.PHP_VERSION }}
                     coverage: none
                     tools: composer:v2
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Cache Composer Dependencies
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: vendor/
                     key: composer-${{ env.PHP_VERSION }}-${{ hashFiles('composer.*') }}

--- a/.github/workflows/fix-cs-php.yml
+++ b/.github/workflows/fix-cs-php.yml
@@ -16,7 +16,7 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v4
+                uses: actions/checkout@v6
                 with:
                     ref: ${{ github.head_ref }}
 

--- a/.github/workflows/php-version-compatibility.yml
+++ b/.github/workflows/php-version-compatibility.yml
@@ -21,5 +21,5 @@ jobs:
                     php-version: ${{ matrix.php }}
                     coverage: none
                     tools: composer:v2
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   run: composer install --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
                     php-version: 8.3
                     coverage: none
                     tools: composer:v2
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Install PHIVE
                 run: |
                     wget --quiet -O phive.phar https://phar.io/releases/phive.phar
@@ -33,7 +33,7 @@ jobs:
                 id: get_version
                 run: echo "VERSION=$(echo $GITHUB_REF | cut -d / -f 3)" >> $GITHUB_OUTPUT
             -   name: Attach .phar to release
-                uses: svenstaro/upload-release-action@v2
+                uses: svenstaro/upload-release-action@2.11.4
                 with:
                     repo_token: ${{ secrets.GITHUB_TOKEN }}
                     file: slimdump.phar

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,9 @@ jobs:
                     php-version: ${{ matrix.php }}
                     coverage: none
                     tools: composer:v2
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v6
             -   name: Cache Composer Dependencies
-                uses: actions/cache@v4
+                uses: actions/cache@v5
                 with:
                     path: vendor/
                     key: composer-${{ matrix.php }}-${{ hashFiles('composer.*') }}


### PR DESCRIPTION
This is to address deprecation notices regarding Node v20 being issued during workflow runs.