### PR TITLE
fix-php85-deprecation-notice Use new constant in php 8.4 or higher to…

### DIFF
--- a/.composer-require-checker.json
+++ b/.composer-require-checker.json
@@ -2,6 +2,7 @@
     "symbol-whitelist": [
         "Doctrine\\Common\\EventSubscriber",
         "Doctrine\\DBAL\\Event\\SchemaColumnDefinitionEventArgs",
-        "Doctrine\\DBAL\\Events"
+        "Doctrine\\DBAL\\Events",
+        "PDO\\Mysql"
     ]
 }

--- a/.github/workflows/fix-cs-php.yml
+++ b/.github/workflows/fix-cs-php.yml
@@ -17,8 +17,6 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v6
-                with:
-                    ref: ${{ github.head_ref }}
 
             -   name: Run PHP-CS-Fixer
                 uses: docker://ghcr.io/php-cs-fixer/php-cs-fixer:3.62.0-php8.3

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -14,6 +14,8 @@ use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webfactory\Slimdump\Config\Table;
 
+use function phpversion;
+
 class Dumper
 {
     /**
@@ -134,7 +136,7 @@ class Dumper
         } else {
             throw new RuntimeException('failed to obtain the wrapped PDO object from the DBAL connection');
         }
-        $pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+        $this->controlBufferedQuery($pdo, false);
         $actualRows = 0;
 
         $this->outputFormatDriver->beginTableDataDump($asset, $tableConfig);
@@ -155,7 +157,7 @@ class Dumper
             $this->progressOutput->writeln(\sprintf('<error>Expected %d rows, actually processed %d – verify results!</error>', $numRows, $actualRows));
         }
 
-        $pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
+        $this->controlBufferedQuery($pdo, true);
 
         $this->outputFormatDriver->endTableDataDump($asset, $tableConfig);
     }
@@ -165,5 +167,15 @@ class Dumper
         $type = $column->getType();
 
         return $type instanceof BlobType || $type instanceof BinaryType;
+    }
+
+    private function controlBufferedQuery(PDO $pdo, bool $value): void
+    {
+        if (version_compare(phpversion(), '8.4.0', '<')) {
+            $pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
+            return;
+        }
+
+        $pdo->setAttribute(PDO\Mysql::ATTR_USE_BUFFERED_QUERY, $value);
     }
 }

--- a/src/Webfactory/Slimdump/Database/Dumper.php
+++ b/src/Webfactory/Slimdump/Database/Dumper.php
@@ -14,8 +14,6 @@ use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 use Webfactory\Slimdump\Config\Table;
 
-use function phpversion;
-
 class Dumper
 {
     /**
@@ -171,8 +169,9 @@ class Dumper
 
     private function controlBufferedQuery(PDO $pdo, bool $value): void
     {
-        if (version_compare(phpversion(), '8.4.0', '<')) {
+        if (version_compare(\PHP_VERSION, '8.4.0', '<')) {
             $pdo->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
+
             return;
         }
 


### PR DESCRIPTION
… avoid deprecation notices

Related to https://github.com/webfactory/slimdump/issues/124