### PR TITLE
fix-php-cs-fixer Fix php cs fixer

### DIFF
--- a/.github/workflows/fix-cs-php.yml
+++ b/.github/workflows/fix-cs-php.yml
@@ -17,8 +17,6 @@ jobs:
         steps:
             -   name: Checkout code
                 uses: actions/checkout@v6
-                with:
-                    ref: ${{ github.head_ref }}
 
             -   name: Run PHP-CS-Fixer
                 uses: docker://ghcr.io/php-cs-fixer/php-cs-fixer:3.62.0-php8.3


### PR DESCRIPTION
Remove the `refs` attribute in the code style job, since it tries to fetch the branch and not the pull request and leads to errors in every PR